### PR TITLE
Several improvements for Servicemesh scenarios

### DIFF
--- a/servicemesh/1-introduction/finish.md
+++ b/servicemesh/1-introduction/finish.md
@@ -1,0 +1,4 @@
+Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE  at <https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/>.
+
+You can also run this tutorial on your machine, visit <http://bit.ly/istio-tutorial>.
+

--- a/servicemesh/1-introduction/index.json
+++ b/servicemesh/1-introduction/index.json
@@ -19,6 +19,9 @@
     "imageid": "openshift-middleware-3-7", "port": 8443
   },
   "details": {
+    "finish": {
+        "text": "finish.md"
+    },
     "intro": {
         "text": "intro.md",
         "credits": "http://developers.redhat.com",

--- a/servicemesh/1-introduction/run-init.sh
+++ b/servicemesh/1-introduction/run-init.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
-ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
+
 ssh root@host01 "rm -rf /root/projects/* /root/temp-pom.xml"
 ssh root@host01 "until $(oc status &> /dev/null); do sleep 1; done; oc adm policy add-cluster-role-to-user cluster-admin admin"
 

--- a/servicemesh/1-introduction/run-init.sh
+++ b/servicemesh/1-introduction/run-init.sh
@@ -4,6 +4,6 @@ ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
 
-ssh root@host01 "rm -rf /root/projects/* /root/temp-pom.xml"
+ssh root@host01 "rm -rf /root/projects/* /root/temp-pom.xml /root/projects/incubator-openwhisk-devtools"
 ssh root@host01 "until $(oc status &> /dev/null); do sleep 1; done; oc adm policy add-cluster-role-to-user cluster-admin admin"
 

--- a/servicemesh/2-deploy-microservices/finish.md
+++ b/servicemesh/2-deploy-microservices/finish.md
@@ -1,0 +1,4 @@
+Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE  at <https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/>.
+
+You can also run this tutorial on your machine, visit <http://bit.ly/istio-tutorial>.
+

--- a/servicemesh/2-deploy-microservices/index.json
+++ b/servicemesh/2-deploy-microservices/index.json
@@ -23,6 +23,9 @@
       "host01": [
       ]
     },
+    "finish": {
+        "text": "finish.md"
+    },
     "intro": {
         "text": "intro.md",
         "credits": "http://developers.redhat.com",

--- a/servicemesh/2-deploy-microservices/run-init.sh
+++ b/servicemesh/2-deploy-microservices/run-init.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
+ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
+
 ssh root@host01 "rm -rf /root/projects/* /root/temp-pom.xml"
 
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 
-ssh root@host01 "sleep 20; oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
+ssh root@host01 "oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
 
 ssh root@host01 "oc adm policy add-cluster-role-to-user cluster-admin developer"
 ssh root@host01 "oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system"

--- a/servicemesh/2-deploy-microservices/run-init.sh
+++ b/servicemesh/2-deploy-microservices/run-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
 
-ssh root@host01 "rm -rf /root/projects/* /root/temp-pom.xml"
+ssh root@host01 "rm -rf /root/projects/* /root/temp-pom.xml /root/projects/incubator-openwhisk-devtools"
 
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 

--- a/servicemesh/3-monitoring-tracing/finish.md
+++ b/servicemesh/3-monitoring-tracing/finish.md
@@ -1,0 +1,4 @@
+Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE  at <https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/>.
+
+You can also run this tutorial on your machine, visit <http://bit.ly/istio-tutorial>.
+

--- a/servicemesh/3-monitoring-tracing/index.json
+++ b/servicemesh/3-monitoring-tracing/index.json
@@ -23,6 +23,9 @@
       "host01": [
       ]
     },
+    "finish": {
+        "text": "finish.md"
+    },
     "intro": {
       "text": "intro.md",
       "credits": "http://developers.redhat.com",

--- a/servicemesh/3-monitoring-tracing/run-init.sh
+++ b/servicemesh/3-monitoring-tracing/run-init.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
+
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
@@ -6,7 +8,7 @@ ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 
-ssh root@host01 "sleep 20; oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
+ssh root@host01 "oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
 
 ssh root@host01 "oc adm policy add-cluster-role-to-user cluster-admin developer"
 ssh root@host01 "oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system"

--- a/servicemesh/3-monitoring-tracing/run-init.sh
+++ b/servicemesh/3-monitoring-tracing/run-init.sh
@@ -5,7 +5,7 @@ ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/
 
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
-ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
+ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml /root/projects/incubator-openwhisk-devtools"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 

--- a/servicemesh/3-monitoring-tracing/run-init.sh
+++ b/servicemesh/3-monitoring-tracing/run-init.sh
@@ -3,7 +3,8 @@ ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
 
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
-ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
 ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"

--- a/servicemesh/4-simple-routerules/finish.md
+++ b/servicemesh/4-simple-routerules/finish.md
@@ -1,0 +1,4 @@
+Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE  at <https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/>.
+
+You can also run this tutorial on your machine, visit <http://bit.ly/istio-tutorial>.
+

--- a/servicemesh/4-simple-routerules/index.json
+++ b/servicemesh/4-simple-routerules/index.json
@@ -23,6 +23,9 @@
       "host01": [
       ]
     },
+    "finish": {
+        "text": "finish.md"
+    },
     "intro": {
       "text": "intro.md",
       "credits": "http://developers.redhat.com",

--- a/servicemesh/4-simple-routerules/run-init.sh
+++ b/servicemesh/4-simple-routerules/run-init.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
+
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
 ssh root@host01 "cp -Rvf /root/projects/istio-tutorial/recommendation/java/vertx /root/projects/istio-tutorial/recommendation-v1"
 
@@ -9,7 +11,7 @@ ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 
-ssh root@host01 "sleep 20; oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
+ssh root@host01 "oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
 
 ssh root@host01 "oc adm policy add-cluster-role-to-user cluster-admin developer"
 ssh root@host01 "oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system"

--- a/servicemesh/4-simple-routerules/run-init.sh
+++ b/servicemesh/4-simple-routerules/run-init.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
 
-ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
 ssh root@host01 "cp -Rvf /root/projects/istio-tutorial/recommendation/java/vertx /root/projects/istio-tutorial/recommendation-v1"
 
 #Install Istio

--- a/servicemesh/4-simple-routerules/run-init.sh
+++ b/servicemesh/4-simple-routerules/run-init.sh
@@ -8,7 +8,7 @@ ssh root@host01 "cp -Rvf /root/projects/istio-tutorial/recommendation/java/vertx
 #Install Istio
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
-ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
+ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml /root/projects/incubator-openwhisk-devtools"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 

--- a/servicemesh/5-advanced-routerules/5rate-limit.md
+++ b/servicemesh/5-advanced-routerules/5rate-limit.md
@@ -10,7 +10,7 @@ Now examine the file that contains the requestcount quota `istiofiles/rate_limit
 
 To check the new behavior, try the microservice several times by typing `while true; do curl http://customer-tutorial.[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com; sleep .1; done`{{execute T1}}
 
-You should see some 429 errors:
+After some seconds, you should see some 429 errors:
 
 ```
 customer => preference => recommendation v2 from '2819441432-f4ls5': 108
@@ -34,7 +34,7 @@ Hit CTRL+C when you are satisfied.
 
 ## Clean up
 
-Execute `istioctl delete -f ~/projects/istio-tutorial/istiofiles/rate_limit_rule.yml`{{execute T1}}
+Execute `istioctl delete -f ~/projects/istio-tutorial/istiofiles/rate_limit_rule.yml`{{execute interrupt T1}}
 
 and 
 

--- a/servicemesh/5-advanced-routerules/finish.md
+++ b/servicemesh/5-advanced-routerules/finish.md
@@ -1,0 +1,4 @@
+Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE  at <https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/>.
+
+You can also run this tutorial on your machine, visit <http://bit.ly/istio-tutorial>.
+

--- a/servicemesh/5-advanced-routerules/index.json
+++ b/servicemesh/5-advanced-routerules/index.json
@@ -34,15 +34,13 @@
       "code": "set-env.sh",
       "courseData": "run-init.sh"
     },
-    "Not WORKING": [
-      { "title": "Rate Limiting", "text": "5rate-limit.md" }
-    ],
     "steps": [
         { "title": "Install microservices", "text": "0install-microservices.md" },
         { "title": "Smart routing based on user-agent header (Canary Deployment)", "text": "1useragent-routing.md" },
         { "title": "Mirroring Traffic (Dark Launch)", "text": "2dark-launch.md" },
         { "title": "Access Control", "text": "3access-control.md" },
-        { "title": "Load Balancer", "text": "4load-balancer.md" }
+        { "title": "Load Balancer", "text": "4load-balancer.md" },
+        { "title": "Rate Limiting", "text": "5rate-limit.md" }
     ]
   }
 }

--- a/servicemesh/5-advanced-routerules/index.json
+++ b/servicemesh/5-advanced-routerules/index.json
@@ -25,6 +25,9 @@
           { "file": "install-microservices.sh", "target": "/root/", "chmod": "+x" }
       ]
     },
+    "finish": {
+        "text": "finish.md"
+    },
     "intro": {
       "text": "intro.md",
       "credits": "http://developers.redhat.com",

--- a/servicemesh/5-advanced-routerules/run-init.sh
+++ b/servicemesh/5-advanced-routerules/run-init.sh
@@ -3,7 +3,9 @@ ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
 
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
-ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
+
 ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"

--- a/servicemesh/5-advanced-routerules/run-init.sh
+++ b/servicemesh/5-advanced-routerules/run-init.sh
@@ -6,7 +6,7 @@ ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
 
-ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
+ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml /root/projects/incubator-openwhisk-devtools"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 

--- a/servicemesh/5-advanced-routerules/run-init.sh
+++ b/servicemesh/5-advanced-routerules/run-init.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
+
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
@@ -6,7 +8,7 @@ ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 
-ssh root@host01 "sleep 20; oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
+ssh root@host01 "oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
 
 ssh root@host01 "oc adm policy add-cluster-role-to-user cluster-admin developer"
 ssh root@host01 "oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system"

--- a/servicemesh/6-fault-injection/finish.md
+++ b/servicemesh/6-fault-injection/finish.md
@@ -1,0 +1,4 @@
+Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE  at <https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/>.
+
+You can also run this tutorial on your machine, visit <http://bit.ly/istio-tutorial>.
+

--- a/servicemesh/6-fault-injection/index.json
+++ b/servicemesh/6-fault-injection/index.json
@@ -25,6 +25,9 @@
           { "file": "install-microservices.sh", "target": "/root/", "chmod": "+x"}
       ]
     },
+    "finish": {
+        "text": "finish.md"
+    },
     "intro": {
       "text": "intro.md",
       "credits": "http://developers.redhat.com",

--- a/servicemesh/6-fault-injection/run-init.sh
+++ b/servicemesh/6-fault-injection/run-init.sh
@@ -3,7 +3,9 @@ ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
 
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
-ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
+
 ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"

--- a/servicemesh/6-fault-injection/run-init.sh
+++ b/servicemesh/6-fault-injection/run-init.sh
@@ -6,7 +6,7 @@ ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
 
-ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
+ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml /root/projects/incubator-openwhisk-devtools"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 

--- a/servicemesh/6-fault-injection/run-init.sh
+++ b/servicemesh/6-fault-injection/run-init.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
+
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
@@ -6,7 +8,7 @@ ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 
-ssh root@host01 "sleep 20; oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
+ssh root@host01 "oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
 
 ssh root@host01 "oc adm policy add-cluster-role-to-user cluster-admin developer"
 ssh root@host01 "oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system"

--- a/servicemesh/7-circuit-breaker/finish.md
+++ b/servicemesh/7-circuit-breaker/finish.md
@@ -1,0 +1,4 @@
+Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE  at <https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/>.
+
+You can also run this tutorial on your machine, visit <http://bit.ly/istio-tutorial>.
+

--- a/servicemesh/7-circuit-breaker/index.json
+++ b/servicemesh/7-circuit-breaker/index.json
@@ -25,6 +25,9 @@
           { "file": "install-microservices.sh", "target": "/root/", "chmod": "+x" }
       ]
     },
+    "finish": {
+        "text": "finish.md"
+    },
     "intro": {
       "text": "intro.md",
       "credits": "http://developers.redhat.com",

--- a/servicemesh/7-circuit-breaker/run-init.sh
+++ b/servicemesh/7-circuit-breaker/run-init.sh
@@ -3,7 +3,9 @@ ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
 
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
-ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
+
 ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"

--- a/servicemesh/7-circuit-breaker/run-init.sh
+++ b/servicemesh/7-circuit-breaker/run-init.sh
@@ -6,7 +6,7 @@ ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
 
-ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
+ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml /root/projects/incubator-openwhisk-devtools"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 

--- a/servicemesh/7-circuit-breaker/run-init.sh
+++ b/servicemesh/7-circuit-breaker/run-init.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
+
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
@@ -6,7 +8,7 @@ ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 
-ssh root@host01 "sleep 20; oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
+ssh root@host01 "oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
 
 ssh root@host01 "oc adm policy add-cluster-role-to-user cluster-admin developer"
 ssh root@host01 "oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system"

--- a/servicemesh/8-egress/finish.md
+++ b/servicemesh/8-egress/finish.md
@@ -1,0 +1,4 @@
+Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE  at <https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/>.
+
+You can also run this tutorial on your machine, visit <http://bit.ly/istio-tutorial>.
+

--- a/servicemesh/8-egress/index.json
+++ b/servicemesh/8-egress/index.json
@@ -19,6 +19,9 @@
     "imageid": "openshift-middleware-3-7", "port": 8443
   },
   "details": {
+    "finish": {
+        "text": "finish.md"
+    },
     "intro": {
       "text": "intro.md",
       "credits": "http://developers.redhat.com",

--- a/servicemesh/8-egress/run-init.sh
+++ b/servicemesh/8-egress/run-init.sh
@@ -3,7 +3,9 @@ ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
 
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
-ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
+ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
+
 ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"

--- a/servicemesh/8-egress/run-init.sh
+++ b/servicemesh/8-egress/run-init.sh
@@ -6,7 +6,7 @@ ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git fetch"
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git checkout katacoda"
 
-ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
+ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml /root/projects/incubator-openwhisk-devtools"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 

--- a/servicemesh/8-egress/run-init.sh
+++ b/servicemesh/8-egress/run-init.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+ssh root@host01 "until (oc status &> /dev/null); do sleep 1; done"
+
 ssh root@host01 "wget -c https://github.com/istio/istio/releases/download/0.6.0/istio-0.6.0-linux.tar.gz -P /root/installation"
 
 ssh root@host01 "git --work-tree=/root/projects/istio-tutorial/ --git-dir=/root/projects/istio-tutorial/.git pull"
@@ -6,7 +8,7 @@ ssh root@host01 "rm -rf /root/projects/rhoar-getting-started /root/temp-pom.xml"
 
 ssh root@host01 "tar -zxvf /root/installation/istio-0.6.0-linux.tar.gz -C /root/installation"
 
-ssh root@host01 "sleep 20; oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
+ssh root@host01 "oc login -u system:admin; oc adm policy add-cluster-role-to-user cluster-admin admin"
 
 ssh root@host01 "oc adm policy add-cluster-role-to-user cluster-admin developer"
 ssh root@host01 "oc adm policy add-scc-to-user anyuid -z istio-ingress-service-account -n istio-system"


### PR DESCRIPTION
This PR contains the following improvements/fixes

- At the end of every scenarios, there is a link to https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/
- Replace "Sleep 20" to wait OpenShift to be started in order to install the microservices and Istio
- The code is pulled from https://github.com/redhat-developer-demos/istio-tutorial/ using the *katacoda* branch.
- Removed /root/projects/incubator-openwhisk-devtools as it is not related to this scenario
- Rate Limiting is now working. 