### PR TITLE
Fix 'middleware/fuse-hello-world' scenario

### DIFF
--- a/middleware/fuse-hello-world/01-creating-an-initial-project.md
+++ b/middleware/fuse-hello-world/01-creating-an-initial-project.md
@@ -1,6 +1,6 @@
 Before we get started, please make sure that you have completed all steps of the Red Hat Fuse Hello World guide.  All set?  Let’s get your OpenShift environment up and running ..
 
-#Setup OpenShift
+# Setup OpenShift
 
 To login to the OpenShift use the following command in the **_Terminal_** frame:
 

--- a/middleware/fuse-hello-world/02-deploying-first-fuse-application-on-openshift.md
+++ b/middleware/fuse-hello-world/02-deploying-first-fuse-application-on-openshift.md
@@ -2,7 +2,7 @@ Let’s get started with building and deploying your application to the **fusela
 
 We will be using OpenShift's Source 2 Image capability, also referred to as **_S2I_** . The OpenShift S2I tool injects application source code into a container image and the final product is a new and ready-to-run container image that incorporates the builder image and built source code. 
 
-To enable this S2I capability, you need to collect the following information and configure it in ***JBoss Developer Studio***. 
+To enable this S2I capability, you need to collect the following information and configure it in ***Red Hat Developer Studio***. 
 
 Right click on your project in the sidebar menu, select Run As > Run Configuration  
 


### PR DESCRIPTION
- Markdown of a caption
- Rename 'JBoss Developer Studio' to the current name of the product 'Red Hat Developer Studio'

Signed-off-by: Tomáš Sedmík <tsedmik@redhat.com>