### PR TITLE
Updating operator-sdk scripts to v0.2.0 release and 1.10 golang.

### DIFF
--- a/ansibleop/ansible-operator-overview/assets/op-sdk-setup.sh
+++ b/ansibleop/ansible-operator-overview/assets/op-sdk-setup.sh
@@ -11,26 +11,17 @@ yum install python-devel -y
 pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --trusted-host pypi.python.org ansible-runner
 pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --trusted-host pypi.python.org ansible-runner-http
 
-#Cleanup - Temporary
-sed -i '/GOROOT/d' ~/.bashrc
-sed -i '/GOBIN/d' ~/.bashrc
-yum remove go -y
-rm -rf $GOPATH/src/github.com/operator-framework
-
 #setup GoLang Environment
 wget https://dl.google.com/go/go1.10.linux-amd64.tar.gz -P /tmp
 tar -C /usr/local -xzf /tmp/go1.10.linux-amd64.tar.gz
 echo "export GOPATH=$HOME/tutorial/go" >> ~/.bashrc
-echo "export PATH=$PATH:/usr/local/go/bin" >> ~/.bashrc
+echo "export GOROOT=/usr/local/go" >> ~./bashrc
+echo "export GOBIN=$GOPATH/bin" >> ~.bashrc
+echo "export PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin" >> ~/.bashrc
 . ~/.bashrc
 
-#setup GoLang Environment
-#yum install go -y
-#echo "export GOPATH=$HOME/tutorial/go" >> ~/.bashrc
-#echo "export GOBIN=$GOPATH/bin" >> ~/.bashrc && mkdir -p $GOPATH/bin
-#echo "export GOROOT=/usr/lib/golang" >> ~/.bashrc
-#echo "export PATH=$PATH:$GOPATH/bin" >> ~/.bashrc
-#. ~/.bashrc
+#ensure needed dirs exists at GOPATH
+mkdir -p $GOPATH/{src,pkg,bin}
 
 #install dep
 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
@@ -41,11 +32,5 @@ cd $GOPATH/src/github.com/operator-framework
 wget https://github.com/operator-framework/operator-sdk/releases/download/v0.2.0/operator-sdk-v0.2.0-x86_64-linux-gnu -O operator-sdk
 chmod +x operator-sdk
 
-#install Operator sdk
-#mkdir -p $GOPATH/src/github.com/operator-framework
-#cd $GOPATH/src/github.com/operator-framework
-#git clone https://github.com/operator-framework/operator-sdk
-#cd operator-sdk
-#git checkout master
-#make dep
-#make install
+git config --global user.email "operator-sdk@example.com"
+git config --global user.name "OperatorSDK Katacoda"

--- a/environments/openshift-3-11/scripts/10_op-sdk-setup.sh
+++ b/environments/openshift-3-11/scripts/10_op-sdk-setup.sh
@@ -13,21 +13,24 @@ pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --trus
 pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --trusted-host pypi.python.org ansible-runner-http
 
 echo "setup GoLang Environment"
-yum install go -y
+wget https://dl.google.com/go/go1.10.linux-amd64.tar.gz -P /tmp
+tar -C /usr/local -xzf /tmp/go1.10.linux-amd64.tar.gz
 echo "export GOPATH=$HOME/tutorial/go" >> ~/.bashrc
-echo "export GOBIN=$GOPATH/bin" >> ~/.bashrc && mkdir -p $GOPATH/bin
-echo "export GOROOT=/usr/lib/golang" >> ~/.bashrc
-echo "export PATH=$PATH:$GOPATH/bin" >> ~/.bashrc
+echo "export GOROOT=/usr/local/go" >> ~./bashrc
+echo "export GOBIN=$GOPATH/bin" >> ~.bashrc
+echo "export PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin" >> ~/.bashrc
 . ~/.bashrc
 
 echo "install dep"
 curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
+#ensure needed dirs exists at GOPATH
+mkdir -p $GOPATH/{src,pkg,bin}
+
 echo "install Operator sdk"
-mkdir -p /root/tutorial/go/src/github.com/operator-framework
-cd /root/tutorial/go/src/github.com/operator-framework
-git clone https://github.com/operator-framework/operator-sdk
-cd operator-sdk
-git checkout master
-make dep
-make install
+mkdir -p $GOPATH/src/github.com/operator-framework
+cd $GOPATH/src/github.com/operator-framework
+wget https://github.com/operator-framework/operator-sdk/releases/download/v0.2.0/operator-sdk-v0.2.0-x86_64-linux-gnu -O operator-sdk
+chmod +x operator-sdk
+git config --global user.email "operator-sdk@example.com"
+git config --global user.name "OperatorSDK Katacoda"


### PR DESCRIPTION
@BenHall @mhausenblas  - We need to update the script for operator-sdk in 3.11 env and rebuild image.  This will provide stability, as we are tagging us to a known release and newer version of golang.