### PR TITLE
Fixing typos in operator-sdk installation script for 3.11 env

### DIFF
--- a/environments/openshift-3-11/scripts/10_op-sdk-setup.sh
+++ b/environments/openshift-3-11/scripts/10_op-sdk-setup.sh
@@ -16,8 +16,8 @@ echo "setup GoLang Environment"
 wget https://dl.google.com/go/go1.10.linux-amd64.tar.gz -P /tmp
 tar -C /usr/local -xzf /tmp/go1.10.linux-amd64.tar.gz
 echo "export GOPATH=$HOME/tutorial/go" >> ~/.bashrc
-echo "export GOROOT=/usr/local/go" >> ~./bashrc
-echo "export GOBIN=$GOPATH/bin" >> ~.bashrc
+echo "export GOROOT=/usr/local/go" >> ~/.bashrc
+echo "export GOBIN=$GOPATH/bin" >> ~/.bashrc
 echo "export PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin" >> ~/.bashrc
 . ~/.bashrc
 


### PR DESCRIPTION
@BenHall This should now be correct.  My bad for missing these in my testing.  Thanks again for your help.