### PR TITLE
Updating script to escape env vars in .bashrc

### DIFF
--- a/ansibleop/ansible-operator-overview/set-env.sh
+++ b/ansibleop/ansible-operator-overview/set-env.sh
@@ -1,2 +1,5 @@
+export GOPATH=/root/tutorial/go
+export GOBIN=/root/tutorial/go/bin
+
 #switch user to tutorial directory
 cd ~/tutorial

--- a/ansibleop/operator-sdk-playground/set-env.sh
+++ b/ansibleop/operator-sdk-playground/set-env.sh
@@ -1,2 +1,5 @@
+export GOPATH=/root/tutorial/go
+export GOBIN=/root/tutorial/go/bin
+
 #switch user to tutorial directory
 cd ~/tutorial

--- a/environments/openshift-3-11/scripts/10_op-sdk-setup.sh
+++ b/environments/openshift-3-11/scripts/10_op-sdk-setup.sh
@@ -15,9 +15,9 @@ pip install --trusted-host files.pythonhosted.org --trusted-host pypi.org --trus
 echo "setup GoLang Environment"
 wget https://dl.google.com/go/go1.10.linux-amd64.tar.gz -P /tmp
 tar -C /usr/local -xzf /tmp/go1.10.linux-amd64.tar.gz
-echo "export GOPATH=$HOME/tutorial/go" >> ~/.bashrc
+echo "export GOPATH=\$HOME/tutorial/go" >> ~/.bashrc
 echo "export GOROOT=/usr/local/go" >> ~/.bashrc
-echo "export GOBIN=$GOPATH/bin" >> ~/.bashrc
+echo "export GOBIN=\$GOPATH/bin" >> ~/.bashrc
 echo "export PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin" >> ~/.bashrc
 . ~/.bashrc
 


### PR DESCRIPTION
@BenHall @mhausenblas @madorn This will fix the GOBIN issue in the 3.11 env.