### PR TITLE
Modify deployment of Operator-Lifecycle-Manager manifests

### DIFF
--- a/operatorframework/operator-lifecycle-manager/step1.md
+++ b/operatorframework/operator-lifecycle-manager/step1.md
@@ -1,12 +1,4 @@
-Let's begin my creating a new project called `myproject`:
-
-```
-oc new-project myproject
-```{{execute}}
-<br>
-We will now deploy the Operator Lifecycle Manager to our OpenShift environment.
-
-It consists of the following objects:
+The Operator Lifecycle Manager is not installed in our current Katacoda OpenShift environment. We will now install it from scratch by deploying the following objects:
 
 * **CustomResourceDefinitions**:
     * `Subscription`, `InstallPlan`, `CatalogSource`, `ClusterServiceVersion`
@@ -24,17 +16,50 @@ It consists of the following objects:
     * `rh-operators`
 * **Deployments**:
     * `olm-operator`, `catalog-operator`, `package-server`
+  
+**Note:** The initial setup of the Operator Lifecycle Manager (OLM) is a one-time task and is reserved for Kubernetes administrators with cluster-admin privileges. Once OLM is properly setup, Kubernetes administrators can then delegate Operator install privileges to non-admin Kubernetes users.
 
-Let's get started by cloning the official Operator Lifecycle Manager repository:
+Let's get started by cloning the official OLM repository:
 
 ```
 git clone https://github.com/operator-framework/operator-lifecycle-manager
 ```{{execute}}
 <br>
-We can now install all the required objects:
+Create the dedicated `openshift-operator-lifecycle-manager` Namespace:
 
 ```
-oc create -f operator-lifecycle-manager/deploy/okd/manifests/0.7.2/
+oc create -f operator-lifecycle-manager/deploy/okd/manifests/0.7.2/0000_30_00-namespace.yaml
+```{{execute}}
+<br>
+Verify the Namespace was successfully created:
+
+```
+oc get namespaces openshift-operator-lifecycle-manager
+```{{execute}}
+<br>
+Create the `olm-operator-serviceaccount` Service Account, `system:controller:operator-lifecycle-manager` ClusterRole, and `olm-operator-binding-openshift-operator-lifecycle-manager` ClusterRoleBinding:
+
+```
+oc create -f operator-lifecycle-manager/deploy/okd/manifests/0.7.2/0000_30_01-olm-operator.serviceaccount.yaml
+```{{execute}}
+<br>
+
+Verify the Service Account, ClusterRole, and ClusterRoleBinding were successfully created:
+
+```
+oc -n openshift-operator-lifecycle-manager get serviceaccount olm-operator-serviceaccount
+```{{execute}}
+```
+oc get clusterrole system:controller:operator-lifecycle-manager
+```{{execute}}
+```
+oc get clusterrolebinding olm-operator-binding-openshift-operator-lifecycle-manager
+```{{execute}}
+
+Create the OLM Custom Resource Definitions (`Subscription`, `InstallPlan`, `CatalogSource`, `ClusterServiceVersion`):
+
+```
+for num in {02..05}; do oc create -f operator-lifecycle-manager/deploy/okd/manifests/0.7.2/0000_30_$num*; done
 ```{{execute}}
 <br>
 Verify all four OLM CRDs are present:
@@ -43,17 +68,31 @@ Verify all four OLM CRDs are present:
 oc get crds
 ```{{execute}}
 <br>
-Verify the Operators are currently running within the `openshift-operator-lifecycle-manager` namespace:
+Create the internal `rh-operators` CatalogSource and `rh-operators` ConfigMap which contains manifests for some popular Operators:
 
 ```
-oc -n openshift-operator-lifecycle-manager get deploy
+for num in {06,09}; do oc create -f operator-lifecycle-manager/deploy/okd/manifests/0.7.2/0000_30_$num*; done
 ```{{execute}}
 <br>
-Verify the CatalogSource and CatalogSource ConfigMap exist:
+Verify the CatalogSource and ConfigMap were successfully created:
 
 ```
-oc get -n openshift-operator-lifecycle-manager catalogsource
+oc -n openshift-operator-lifecycle-manager get catalogsource rh-operators
 ```{{execute}}
 ```
-oc get -n openshift-operator-lifecycle-manager configmap
+oc -n openshift-operator-lifecycle-manager get configmap rh-operators
 ```{{execute}}
+<br>
+Create the remaining OLM objects including OLM, Catalog, and Package Deployments:
+
+```
+for num in {10..13}; do oc create -f operator-lifecycle-manager/deploy/okd/manifests/0.7.2/0000_30_$num*; done
+```{{execute}}
+<br>
+Verify all three OLM deployments were successfully created:
+
+```
+oc -n openshift-operator-lifecycle-manager get deployments
+```{{execute}}
+<br>
+We have successfully setup the Operator Lifecycle Manager in our OpenShift cluster.


### PR DESCRIPTION
When deploying Operator Lifecycle Manager via Kubernetes manifests, avoid possible race condition on slower systems by creating creating OLM objects in separate steps.