### PR TITLE
Specify myproject namespace when initially listing pods 

### DIFF
--- a/operatorframework/k8s-api-fundamentals/step3.md
+++ b/operatorframework/k8s-api-fundamentals/step3.md
@@ -1,7 +1,7 @@
-Get a list of all pods in the default namespace:
+Get a list of all pods in the `myproject` Namespace:
 
 ```
-oc get pods
+oc get pods -n myproject
 ```{{execute}}
 <br>
 Create a ReplicaSet object manifest file:


### PR DESCRIPTION
Specify myproject namespace when initially listing pods on ReplicaSet exercise.