### PR TITLE
Add dep install to operator-sdk (go-based) module

### DIFF
--- a/operatorframework/go-operator-podset/env-init.sh
+++ b/operatorframework/go-operator-podset/env-init.sh
@@ -12,3 +12,5 @@ ssh root@host01 'cp -r ~/.kube/config ~/backup/.kube/'
 #ssh root@host01 'rm -rf ~/.kube/config  >> /dev/null'
 
 ssh root@host01 'yum install jq -y'
+
+ssh root@host01 'curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh'


### PR DESCRIPTION
`dep` does not show up in the operator-sdk (go-based) module environment, although it's set in the environment script: https://github.com/openshift-labs/learn-katacoda/blob/master/environments/openshift-3-11/scripts/10_op-sdk-setup.sh#L28

As a workaround, add it to `env-init.sh`.