### PR TITLE
fix various typos in operator-sdk (go-based) module

### DIFF
--- a/operatorframework/go-operator-podset/step2.md
+++ b/operatorframework/go-operator-podset/step2.md
@@ -4,7 +4,7 @@ Add a new Custom Resource Definition(CRD) API called PodSet, with APIVersion `ap
 operator-sdk add api --api-version=app.example.com/v1alpha1 --kind=PodSet
 ```{{execute}}
 <br>
-This will scaffold the PodSet resource API under `pkg/apis/cache/v1alpha1/...`.
+This will scaffold the PodSet resource API under `pkg/apis/app/v1alpha1/...`.
 
 The Operator-SDK automatically creates the following manifests for you under the `/deploy` directory.
 

--- a/operatorframework/go-operator-podset/step5.md
+++ b/operatorframework/go-operator-podset/step5.md
@@ -170,7 +170,7 @@ func (r *ReconcilePodSet) Reconcile(request reconcile.Request) (reconcile.Result
 		}
 		err = r.client.Create(context.TODO(), pod)
 		if err != nil {
-			reqLogger.Error(err, "Failed to delete pod", "pod.name", pod.Name)
+			reqLogger.Error(err, "Failed to create pod", "pod.name", pod.Name)
 			return reconcile.Result{}, err
 		}
 		return reconcile.Result{Requeue: true}, nil

--- a/operatorframework/go-operator-podset/step6.md
+++ b/operatorframework/go-operator-podset/step6.md
@@ -1,4 +1,4 @@
-Now we can test our logic by running our Operator outside the cluster via our `kubeconfig` credentials:
+Now we can test our logic by running our Operator outside the cluster via our `kubeconfig` credentials. Once running, the command will block the current session. You can continue interacting with the OpenShift cluster by opening a new terminal window.
 
 ```
 operator-sdk up local --namespace myproject


### PR DESCRIPTION
fix various typos in operator-sdk (go-based) module