### PR TITLE
Dep missing from go-operator-podset environment

### DIFF
--- a/operatorframework/go-operator-podset/env-init.sh
+++ b/operatorframework/go-operator-podset/env-init.sh
@@ -12,5 +12,3 @@ ssh root@host01 'cp -r ~/.kube/config ~/backup/.kube/'
 #ssh root@host01 'rm -rf ~/.kube/config  >> /dev/null'
 
 ssh root@host01 'yum install jq -y'
-
-ssh root@host01 'curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh'

--- a/operatorframework/go-operator-podset/set-env.sh
+++ b/operatorframework/go-operator-podset/set-env.sh
@@ -1,5 +1,6 @@
 wget https://github.com/operator-framework/operator-sdk/releases/download/v0.2.1/operator-sdk-v0.2.1-x86_64-linux-gnu -O /root/tutorial/go/bin/operator-sdk
 chmod +x /root/tutorial/go/bin/operator-sdk
 export GOBIN=/root/tutorial/go/bin
+curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 #switch user to tutorial directory
 cd ~/tutorial


### PR DESCRIPTION
Although #329 was merged - I am still not seeing `dep` installed in the environment.

As a temporary workaround (like the operator-sdk install), I've added it to set-env.sh.

Thanks!