### PR TITLE
remove verification of new resource check via cli

### DIFF
--- a/operatorframework/etcd-operator/step1.md
+++ b/operatorframework/etcd-operator/step1.md
@@ -40,8 +40,3 @@ Verify the CRD was successfully created.
 ```
 oc get crd
 ```{{execute}}
-<br>
-```
-oc get etcdcluster
-```{{execute}}
-<br>

--- a/operatorframework/go-operator-podset/step2.md
+++ b/operatorframework/go-operator-podset/step2.md
@@ -33,9 +33,3 @@ Confirm the CRD was successfully created:
 oc get crd
 ```{{execute}}
 <br>
-Verify there are no current PodSets created:
-
-```
-oc get podset
-```{{execute}}
-<br>

--- a/operatorframework/go-operator-podset/step2.md
+++ b/operatorframework/go-operator-podset/step2.md
@@ -32,4 +32,3 @@ Confirm the CRD was successfully created:
 ```
 oc get crd
 ```{{execute}}
-<br>


### PR DESCRIPTION
remove verification of new CRD `Kind:` via `oc`. The ` No resources found` output seems to be confusing to some participants.