### PR TITLE
adds --skip-git-init, which was accidentally removed in a prior change

### DIFF
--- a/ansibleop/ansible-operator-overview/step5.md
+++ b/ansibleop/ansible-operator-overview/step5.md
@@ -65,7 +65,7 @@ __Now it's your turn!__ We'll be building a [__Memcached__](https://memcached.or
 
 Go ahead and run the command below to generate the Ansible Operator project scaffolding.
 
-`operator-sdk new memcached-operator --type=ansible --api-version=cache.example.com/v1alpha1 --kind=Memcached`{{execute}}
+`operator-sdk new memcached-operator --type=ansible --api-version=cache.example.com/v1alpha1 --kind=Memcached --skip-git-init`{{execute}}
 
 This creates a new memcached-operator project specifically for watching the
 Memcached resource with APIVersion 'cache.example.com/v1apha1' and Kind


### PR DESCRIPTION
The `operator-sdk new` command will by default attempt to initialize a git repo. Since user info
has not been configured for git in the learning environment, this causes an error. The solution is to
use the --skip-git-init flag. This was accidentally removed in https://github.com/openshift-labs/learn-katacoda/pull/337.