### PR TITLE
Use StatusWriter to Update podNames status

### DIFF
--- a/operatorframework/go-operator-podset/step5.md
+++ b/operatorframework/go-operator-podset/step5.md
@@ -139,7 +139,7 @@ func (r *ReconcilePodSet) Reconcile(request reconcile.Request) (reconcile.Result
 	}
 	if !reflect.DeepEqual(podSet.Status, status) {
 		podSet.Status = status
-		err = r.client.Update(context.TODO(), podSet)
+		err = r.client.Status().Update(context.TODO(), podSet)
 		if err != nil {
 			reqLogger.Error(err, "Failed to update PodSet status")
 			return reconcile.Result{}, err


### PR DESCRIPTION
operator-sdk v0.3.0+ automatically sets status subresource on CRD - use StatusWriter (client.Status().Update) to publish podNames status (instead of client.Update).

@marekjelen  @BenHall