### PR TITLE
Add Page Location Language to Getting Started Tutorial

### DIFF
--- a/introduction/getting-started/4scaling.md
+++ b/introduction/getting-started/4scaling.md
@@ -26,7 +26,7 @@ Since we have two *Pods* running right now, let's see what happens if we
 
 On the same page where you viewed the list of pods after scaling to 2 replicas, open one of the pods by clicking its name in the list.
 
-In the top right corner of the page there is _Actions_ tab. When opened, there is the _Delete_ action.
+In the top right corner of the page, there is _Actions_ tab. When opened, there is the _Delete_ action.
 
 ![Delete action](../../assets/introduction/getting-started/4scaling-actions.png)
 

--- a/introduction/getting-started/4scaling.md
+++ b/introduction/getting-started/4scaling.md
@@ -24,7 +24,7 @@ situation if it is ever not right. You would be correct!
 Since we have two *Pods* running right now, let's see what happens if we
 "accidentally" kill one.
 
-Open one of the pods by clicking its name in the list.
+On the same page where you viewed the list of pods after scaling to 2 replicas, open one of the pods by clicking its name in the list.
 
 In the top right corner of the page there is _Actions_, when opened, there is _Delete_ action.
 

--- a/introduction/getting-started/4scaling.md
+++ b/introduction/getting-started/4scaling.md
@@ -26,7 +26,7 @@ Since we have two *Pods* running right now, let's see what happens if we
 
 On the same page where you viewed the list of pods after scaling to 2 replicas, open one of the pods by clicking its name in the list.
 
-In the top right corner of the page there is _Actions_, when opened, there is _Delete_ action.
+In the top right corner of the page there is _Actions_ tab. When opened, there is the _Delete_ action.
 
 ![Delete action](../../assets/introduction/getting-started/4scaling-actions.png)
 


### PR DESCRIPTION
This pull request aims to add a minor language update to the `Step 4 - Scaling Your Application` section of the `Getting Started with OpenShift for Developers` tutorial.

As part of going through the `Getting Started with OpenShift for Developers` tutorial my first time, I actually wanted to navigate back to the `Overview` screen of my project before moving on to the `Application "Self Healing"` portion of the section. This caused me to not see the `Actions` tab when moving forward in the tutorial and led to some minor confusion. 

I propose adding some simple language to the tutorial to assure the user knows how to find the `Actions` tab to delete the pod to illustrate OpenShift's self healing capabilities. 