### PR TITLE
Correctly refer to the tutorial by Go (not Ansible)

### DIFF
--- a/operatorframework/go-operator-podset/finish.md
+++ b/operatorframework/go-operator-podset/finish.md
@@ -1,4 +1,4 @@
-Thank you for taking a closer look at the *Ansible Operator*.  For more
+Thank you for taking a closer look at the *Go Operator*.  For more
 Information, check out the links below:
 
 ## Git Hub


### PR DESCRIPTION
This is a Go-based tutorial and not an Ansible tutorial and so it should refer to itself accordingly.

See issue #379 for more details and the topic of whether or not later Ansible references are desired for this Go tutorial.