### PR TITLE
Do not remove admin .kube/config upon environment initalization

### DIFF
--- a/ansibleop/ansible-operator-overview/env-init.sh
+++ b/ansibleop/ansible-operator-overview/env-init.sh
@@ -10,6 +10,6 @@ ssh root@host01 'mkdir -p ~/backup/.kube'
 ssh root@host01 'cp -r ~/.kube/config ~/backup/.kube/'
 
 #Remove the existing ~/.kube/config -> this addresses a untrusted cert issue
-ssh root@host01 'rm -rf ~/.kube/config  >> /dev/null'
+#ssh root@host01 'rm -rf ~/.kube/config  >> /dev/null'
 
 ssh root@host01 'yum install jq -y'


### PR DESCRIPTION
Ansible-Operator exercise should allow you to build and deploy operator via admin user. Prevent removal of .kube/config file in environment initialization.