### PR TITLE
Remove logging in as 'developer' user

### DIFF
--- a/ansibleop/ansible-operator-overview/step7.md
+++ b/ansibleop/ansible-operator-overview/step7.md
@@ -1,25 +1,9 @@
-Login to OpenShift as the developer user:
-
-`oc login -u developer -p developer [[HOST_SUBDOMAIN]]-8443-[[KATACODA_HOST]].environments.katacoda.com`{{execute}}
-
-This will log you in using the credentials:
-
-* **Username:** ``developer``
-* **Password:** ``developer``
-
-Use the same credentials to log into the web console.
-
-In order that you can still run commands from the command line as a cluster
-admin, the ``sudoer`` Role has been enabled for the ``developer`` account.
-To execute a command as a cluster admin add the ``--as system:admin`` option
-to the command.
-
 Before running the Operator, Kubernetes needs to know about the new custom
 resource definition the Operator will be watching.
 
 ### Deploy the Memcached Custom Resource Definition (CRD):
 
-`oc create -f deploy/crds/cache_v1alpha1_memcached_crd.yaml --as system:admin`{{execute}}
+`oc create -f deploy/crds/cache_v1alpha1_memcached_crd.yaml`{{execute}}
 
 By running this command, we are creating a new resource type, `memcached`, on the cluster. __We will give our Operator work to do by creating and modifying resources of this type.__
 
@@ -80,10 +64,10 @@ Create Service Account for Operator to run as
 `oc create -f deploy/service_account.yaml`{{execute}}
 
 Create OpenShift Role specifying Operator Permissions
-`oc create -f deploy/role.yaml --as system:admin`{{execute}}
+`oc create -f deploy/role.yaml`{{execute}}
 
 Create OpenShift Role Binding assigning Permissions to Service Account
-`oc create -f deploy/role_binding.yaml --as system:admin`{{execute}}
+`oc create -f deploy/role_binding.yaml`{{execute}}
 
 Create Operator Deployment Object
 `oc create -f deploy/operator.yaml`{{execute}}

--- a/ansibleop/ansible-operator-overview/step8.md
+++ b/ansibleop/ansible-operator-overview/step8.md
@@ -30,7 +30,7 @@ spec:
   size: 3
 ```
 
-`oc create -f deploy/crds/cache_v1alpha1_memcached_cr.yaml --as system:admin`{{execute}}
+`oc create -f deploy/crds/cache_v1alpha1_memcached_cr.yaml`{{execute}}
 
 ## Check that the Memcached Operator works as intended 
 Ensure that the memcached-operator creates the deployment for the CR:
@@ -73,7 +73,7 @@ spec:
   size: 4
 </pre>
 
-`oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml --as system:admin`{{execute}}
+`oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml`{{execute}}
 
 Confirm that the Operator changes the deployment size:
 
@@ -88,13 +88,13 @@ memcached-operator  1       1        1           1          5m
 
 Inspect the YAML list of 'memcached' resources in your project, noting that the 'spec.size' field is now set to 4.
 
-`oc get memcached  -o yaml --as system:admin`{{execute}}
+`oc get memcached  -o yaml`{{execute}}
 
 ## Removing Memcached from the cluster 
 
 First, delete the 'memcached' CR, which will remove the 4 Memcached pods and the associated deployment.
 
-`oc delete -f deploy/crds/cache_v1alpha1_memcached_cr.yaml --as system:admin`{{execute}}
+`oc delete -f deploy/crds/cache_v1alpha1_memcached_cr.yaml`{{execute}}
 
 <small>
 ```sh


### PR DESCRIPTION
Now that the system:admin .kube/config file remains, remove logging in as 'developer' user and perform all actions as system:admin for simple user experience.