### PR TITLE
Remove Podset from "Operator SDK with Go" title

### DIFF
--- a/operatorframework-pathway.json
+++ b/operatorframework-pathway.json
@@ -15,7 +15,7 @@
     {
       "external_link": "https://learn.openshift.com/operatorframework/go-operator-podset/",
       "course_id": "go-operator-podset",
-      "title": "Operator SDK with Go (PodSet)"
+      "title": "Operator SDK with Go"
     },
     {
       "external_link": "https://learn.openshift.com/operatorframework/operator-lifecycle-manager/",

--- a/operatorframework/go-operator-podset/index.json
+++ b/operatorframework/go-operator-podset/index.json
@@ -1,7 +1,7 @@
 {
   "icon": "fa-openshift",
-  "title": "Operator SDK with Go (PodSet)",
-  "description": "Operator SDK with Go (PodSet)",
+  "title": "Operator SDK with Go",
+  "description": "Operator SDK with Go",
   "pathwayTitle": "OpenShift",
   "difficulty": "beginner",
   "time": "30 minutes",


### PR DESCRIPTION
For module title uniformity, Remove "Podset" from "Operator SDK with Go" title