### PR TITLE
Make it more clear the commands are separate

### DIFF
--- a/subsystems/container-internals-lab-2-0-part-1/04-hosts.md
+++ b/subsystems/container-internals-lab-2-0-part-1/04-hosts.md
@@ -22,7 +22,9 @@ Containers are just regular Linux processes that were started as child processes
 Execute a few commands with podman and notice the process IDs, and namespace IDs. Containers are just regular processes:
 
 `podman ps -ns`{{execute}}
+
 `podman top -l huser user hpid pid %C etime tty time args`{{execute}}
+
 `ps -ef | grep 3306`{{execute}}
 
 We will explore this deeper in later labs but, for now, commit this to memory, containers are simply Linux ...


### PR DESCRIPTION
Without the extra newline, there's no whitespace between the commands and at a glance it gives the impression that they're not separate commands:

> ![container-internals-20-lab1-step4](https://user-images.githubusercontent.com/346123/57468727-0e57d500-7253-11e9-8201-6d71cfe8839a.png)