### PR TITLE
Fix partial match docker image

### DIFF
--- a/introduction/using-metrics/2sample-application.md
+++ b/introduction/using-metrics/2sample-application.md
@@ -42,7 +42,7 @@ to build a new example application in Ruby.
 
 We will deploy a sample application:
 
-``oc new-app kubernetes/guestbook``{{execute}}
+``oc new-app --docker-image="docker.io/kubernetes/guestbook:latest"``{{execute}}
 
 Once the pod has been created, the metrics components will start to gather
 information. To check the metrics using ``oc``, it is required to be


### PR DESCRIPTION
Error occurring previous to this change when running the new-app stage is shown as below.

$ oc new-app kubernetes/guestbook
error: Errors occurred while determining argument types:

kubernetes/guestbook as a local directory pointing to a Git repository:  stat kubernetes/guestbook: no such file or directory

Errors occurred during resource creation:
error: only a partial match was found for "kubernetes/guestbook": "docker.io/kubernetes/guestbook:latest"

The argument "kubernetes/guestbook" only partially matched the following Docker image, OpenShift image stream, or template:

* Docker image "docker.io/kubernetes/guestbook:latest", 7dc61f8, from local, 11.827mb
  Use --docker-image="docker.io/kubernetes/guestbook:latest" to specify this image or template