### PR TITLE
Adding Download of odo v1.0.0-beta2 to Fix Odo Tutorial

### DIFF
--- a/introduction/developing-with-odo/set-env.sh
+++ b/introduction/developing-with-odo/set-env.sh
@@ -17,8 +17,8 @@ clear
 
 odo utils config set UpdateNotification false > /dev/null 2>&1
 oc create -f volumes.json --as system:admin
-oc import-image -n openshift java --as system:admin 1> /dev/null 
-oc import-image -n openshift nodejs --as system:admin 1> /dev/null 
+oc import-image -n openshift java --as system:admin 1> /dev/null
+oc import-image -n openshift nodejs --as system:admin 1> /dev/null
 
 clear
 
@@ -28,5 +28,9 @@ git clone https://github.com/openshift-evangelists/Wild-West-Frontend.git ~/fron
 
 clear
 
-echo "Configuration completed"
+echo "Downloading odo v1.0.0-beta2"
+sudo curl -L https://github.com/redhat-developer/odo/releases/download/v1.0.0-beta2/odo-linux-amd64 -o /usr/local/bin/odo && sudo chmod +x /usr/local/bin/odo
 
+clear
+
+echo "Configuration completed"


### PR DESCRIPTION
This pull request is a temporary way to address #472. This will set up the tutorial environment with the correct version of `odo` needed for the tutorial. This does not fully address #472 as the ideal solution will be to not have to install `odo` each time the scenario is launched, but it will temporarily fix the scenario for users. 