### PR TITLE
Removing odo v1.0.0-beta2 Download

### DIFF
--- a/introduction/developing-with-odo/set-env.sh
+++ b/introduction/developing-with-odo/set-env.sh
@@ -28,9 +28,4 @@ git clone https://github.com/openshift-evangelists/Wild-West-Frontend.git ~/fron
 
 clear
 
-echo "Downloading odo v1.0.0-beta2"
-sudo curl -L https://github.com/redhat-developer/odo/releases/download/v1.0.0-beta2/odo-linux-amd64 -o /usr/local/bin/odo && sudo chmod +x /usr/local/bin/odo
-
-clear
-
 echo "Configuration completed"


### PR DESCRIPTION
Closes #472 

This pull request removes the installation of `odo v1.0.0-beta2` for the `Developing with odo` tutorial. The issue with #472 was that there was a hardcoded in workaround that had been used for helping upgrade the tutorial to `odo v0.0.17` that was not allowing the new version of `odo` to be used. This workaround has been removed, so it will no longer override the binary in the OpenShift 3.11 image used for the tutorial. The OpenShift 3.11 image now has `odo v1.0.0-beta2` correctly installed. 