### PR TITLE
Update Linking Components Content for Developing with odo

### DIFF
--- a/introduction/developing-with-odo/04-linking-components.md
+++ b/introduction/developing-with-odo/04-linking-components.md
@@ -4,12 +4,14 @@ To link the current `frontend` component to the `backend`, you can run:
 
 `odo link backend --component frontend --port 8080`{{execute}}
 
-This will inject configuration information into the `frontend` about the `backend` and then restart the `frontend` upon running an `odo push`.
+This will inject configuration information into the `frontend` about the `backend` and then restart the `frontend` component.
 
-The following output will be displayed to confirm the linking information has been added to the configuration of the `frontend` and `backend` components:
+The following output will be displayed to confirm the linking information has been added to the `frontend` component:
 
 ```
  ✓  Component backend has been successfully linked from the component frontend
 ```
 
-Before we push the linking updates, let's make some other changes in `frontend`'s configuration.
+This change will cause the `frontend` component to be restarted so that the linking information will now be used by `frontend`.
+
+Now that the `frontend` component has been linked with the `backend` component, let's make `frontend` publicly accessible.

--- a/introduction/developing-with-odo/04-linking-components.md
+++ b/introduction/developing-with-odo/04-linking-components.md
@@ -12,6 +12,4 @@ The following output will be displayed to confirm the linking information has be
  ✓  Component backend has been successfully linked from the component frontend
 ```
 
-This change will cause the `frontend` component to be restarted so that the linking information will now be used by `frontend`.
-
 Now that the `frontend` component has been linked with the `backend` component, let's make `frontend` publicly accessible.

--- a/introduction/developing-with-odo/05-exposing-components-to-public.md
+++ b/introduction/developing-with-odo/05-exposing-components-to-public.md
@@ -1,4 +1,4 @@
-We have deployed our application's `backend` component and updated both components' configurations to connect the `frontend` component to the `backend`. Let's create an external URL for our application so we can see it in action:
+We have updated `frontend` to be linked with `backend` to allow our application's components to communicate. Let's now create an external URL for our application so we can see it in action:
 
 `odo url create frontend --port 8080`{{execute}}
 
@@ -10,7 +10,7 @@ Once the URL has been created in the `frontend` component's configuration, you w
 To create URL on the OpenShift cluster, please run `odo push`
 ```
 
-The changes can now be pushed:
+The change can now be pushed:
 
 `odo push`{{execute}}
 

--- a/introduction/developing-with-odo/set-env.sh
+++ b/introduction/developing-with-odo/set-env.sh
@@ -3,7 +3,6 @@ echo "Configuring scenario"
 
 curl -LO https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem > /dev/null 2>&1
 oc login -u developer -p developer https://master:8443 --certificate-authority=lets-encrypt-x3-cross-signed.pem --insecure-skip-tls-verify=true > /dev/null 2>&1
-# java-is-insecure.json
 curl -kL https://gist.github.com/jorgemoralespou/033c27a354406d7c5111711346e79b01/raw 2> /dev/null | oc apply -n openshift --as system:admin -f -
 
 clear


### PR DESCRIPTION
This pull request corrects information in the content for the `Developing with odo` tutorial. Currently, the tutorial states that linking components is not finished via `odo` until an `odo push` occurs. However, running `odo link backend --component frontend --port 8080` does not require an `odo push` to link the components in the scenario. The `frontend` component is restarted with the linking information after running `odo link backend --component frontend --port 8080`. 