### PR TITLE
Update odo utils config to odo preference to Suppress Version Update Warning

### DIFF
--- a/introduction/developing-with-odo/set-env.sh
+++ b/introduction/developing-with-odo/set-env.sh
@@ -14,7 +14,7 @@ chmod 0777 /data/pv-*; chcon -t svirt_sandbox_file_t /data/pv-*;
 
 clear
 
-odo utils config set UpdateNotification false > /dev/null 2>&1
+odo preference set UpdateNotification false > /dev/null 2>&1
 oc create -f volumes.json --as system:admin
 oc import-image -n openshift java --as system:admin 1> /dev/null
 oc import-image -n openshift nodejs --as system:admin 1> /dev/null


### PR DESCRIPTION
`odo utils config set UpdateNotification false` is no longer the way to suppress a version update warning with `odo`. This has been changed to `odo preference set UpdateNotification false`. 

For more information on this, please view the `odo` issues I opened [here](https://github.com/openshift/odo/issues/1835).