### PR TITLE
Fix flags and typos in lab7 part1

### DIFF
--- a/subsystems/container-internals-lab-2-0-part-7/01-podman.md
+++ b/subsystems/container-internals-lab-2-0-part-7/01-podman.md
@@ -41,7 +41,7 @@ We can even delete all of the locally cached images with a single command:
 
 ``podman rmi --all``{{execute}}
 
-The above commands show how easy and elegant podman is to use. Now, lets analyse a couple of intersting things that makes Podman different than Docker - it doesn't use a client server model, which is useful for wireing it into CI/CD systems, and other schedulers like Yarn:
+The above commands show how easy and elegant podman is to use. Now, lets analyse a couple of intersting things that makes Podman different than Docker - it doesn't use a client server model, which is useful for wiring it into CI/CD systems, and other schedulers like Yarn:
 
 ## Terminal 1
 
@@ -89,6 +89,6 @@ Or like this with Docker engine:
 
 ``systemd -> dockerd -> containerd -> docker-shim -> runc -> bash``
 
-The conmon utility and docker-shim both serve the same purpose. When the first conmon finishes calling the second, it exits. This disconnects the second conmon and all of its child processes from the container engine, podman. The secondary conmon is then inherited by init (systemd), the first process running on when the system boots. This simplified, daemonless model with podman can be quite useufl when wiring it into other larger systems, like CI/CD, scripts, etc.
+The conmon utility and docker-shim both serve the same purpose. When the first conmon finishes calling the second, it exits. This disconnects the second conmon and all of its child processes from the container engine, podman. The secondary conmon is then inherited by init (systemd), the first process running on when the system boots. This simplified, daemonless model with podman can be quite useuful when wiring it into other larger systems, like CI/CD, scripts, etc.
 
 Alright, now that we know how to run containers, lets move on to building...

--- a/subsystems/container-internals-lab-2-0-part-7/01-podman.md
+++ b/subsystems/container-internals-lab-2-0-part-7/01-podman.md
@@ -31,15 +31,15 @@ bash      root   root    1     ?      filter    system_u:system_r:container_t:s0
 
 Now, stop all of the running containers. No more one liners, it's just built in with Podman:
 
-``podman stop -all``{{execute}}
+``podman stop --all``{{execute}}
 
 Remove all of the actively defined containers. It should be noted that this might be described as deleting the copy-on-write layer, config.json (commonly referred to as the Config Bundle) as well as any state data (whether the container is defined, running, etc):
 
-``podman rm -all``{{execute}}
+``podman rm --all``{{execute}}
 
 We can even delete all of the locally cached images with a single command:
 
-``podman rmi -all``{{execute}}
+``podman rmi --all``{{execute}}
 
 The above commands show how easy and elegant podman is to use. Now, lets analyse a couple of intersting things that makes Podman different than Docker - it doesn't use a client server model, which is useful for wireing it into CI/CD systems, and other schedulers like Yarn:
 

--- a/subsystems/container-internals-lab-2-0-part-7/01-podman.md
+++ b/subsystems/container-internals-lab-2-0-part-7/01-podman.md
@@ -89,6 +89,6 @@ Or like this with Docker engine:
 
 ``systemd -> dockerd -> containerd -> docker-shim -> runc -> bash``
 
-The conmon utility and docker-shim both serve the same purpose. When the first conmon finishes calling the second, it exits. This disconnects the second conmon and all of its child processes from the container engine, podman. The secondary conmon is then inherited by init (systemd), the first process running on when the system boots. This simplified, daemonless model with podman can be quite useuful when wiring it into other larger systems, like CI/CD, scripts, etc.
+The conmon utility and docker-shim both serve the same purpose. When the first conmon finishes calling the second, it exits. This disconnects the second conmon and all of its child processes from the container engine, podman. The secondary conmon is then inherited by init (systemd), the first process running on when the system boots. This simplified, daemonless model with podman can be quite useful when wiring it into other larger systems, like CI/CD, scripts, etc.
 
 Alright, now that we know how to run containers, lets move on to building...


### PR DESCRIPTION
In lab 7 
for the commands: "podman stop / rm / rmi" the flag should be "--all" not "-all".

And there were typos that I have fixed. 

I kinda like this contributing thing but I want to do it over code. Any suggestions?