### PR TITLE
Fixed typos and text

### DIFF
--- a/middleware/rhoar-getting-started-nodejs/03-deploy-to-openshift.md
+++ b/middleware/rhoar-getting-started-nodejs/03-deploy-to-openshift.md
@@ -10,14 +10,16 @@ This uses NPM and the [Nodeshift](https://github.com/bucharest-gold/nodeshift) p
 application to OpenShift using the containerized Node.js runtime. Nodeshift uses the files in the `.nodeshift`
 directory of the sample project to create the necessary Kubernetes objects to cause the application to be deployed.
 
-The build and deploy may take a minute or two. Wait for it to complete. You should see `INFO done` at the end of the build output, and you
+The build and deploy may take a minute or two. Wait for it to complete. You should see `INFO complete` at the end of the build output, and you
 should not see any obvious errors or failures.
 
 After the build finishes it will take less than a minute for the application to become available.
-To verify that everything is started, run the following command and wait for it report
-`replication controller "nodejs-configmap-1" successfully rolled out`
+To verify that everything is started, run the following command
 
 ``oc rollout status dc/nodejs-configmap``{{execute}}
+
+You should then see 
+`replication controller "nodejs-configmap-1" successfully rolled out`
 
 ** 2. Access the application running on OpenShift**
 

--- a/middleware/rhoar-getting-started-nodejs/05-add-logic-for-retrieving-configmaps.md
+++ b/middleware/rhoar-getting-started-nodejs/05-add-logic-for-retrieving-configmaps.md
@@ -1,6 +1,6 @@
 We are now ready to change our application to use ConfigMaps!
 
-In the sample application this is the hard-coded message that is returned to the caller of the service:
+In the sample application, this is the hard-coded message that is returned to the caller of the service:
 
 ```javascript
 let message = "Default hard-coded greeting: Hello, %s!";

--- a/middleware/rhoar-getting-started-nodejs/05-add-logic-for-retrieving-configmaps.md
+++ b/middleware/rhoar-getting-started-nodejs/05-add-logic-for-retrieving-configmaps.md
@@ -1,6 +1,6 @@
 We are now ready to change our application to use ConfigMaps!
 
-In the sample application is the hard-coded message that is returned to the caller of the service:
+In the sample application this is the hard-coded message that is returned to the caller of the service:
 
 ```javascript
 let message = "Default hard-coded greeting: Hello, %s!";

--- a/middleware/rhoar-getting-started-nodejs/07-redeploy-to-openshift.md
+++ b/middleware/rhoar-getting-started-nodejs/07-redeploy-to-openshift.md
@@ -5,10 +5,12 @@ With our code and ConfigMap in place, lets rebuild and redeploy using the same c
 The rebuild and redeploy may take a minute or two. Wait for it to complete.
 
 After the build finishes it will take less than a minute for the application to become available.
-To verify that everything is started, run the following command and wait for it report
-`replication controller "nodejs-configmap-2" successfully rolled out`
+To verify that everything is started, run the following command again
 
 ``oc rollout status dc/nodejs-configmap``{{execute}}
+
+and wait for it report
+`replication controller "nodejs-configmap-2" successfully rolled out`
 
 Once the application is re-deployed, re-visit the sample UI by clicking the
 [application link](http://nodejs-configmap-example.[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com)

--- a/middleware/rhoar-getting-started-nodejs/07-redeploy-to-openshift.md
+++ b/middleware/rhoar-getting-started-nodejs/07-redeploy-to-openshift.md
@@ -9,7 +9,7 @@ To verify that everything is started, run the following command again
 
 ``oc rollout status dc/nodejs-configmap``{{execute}}
 
-and wait for it report
+and wait for it to report
 `replication controller "nodejs-configmap-2" successfully rolled out`
 
 Once the application is re-deployed, re-visit the sample UI by clicking the


### PR DESCRIPTION
Running "nodeshift" will give the message "complete", not "done"

Changed the way the text was structured in the `oc rollout` part to make it less confusing (command, then output)