### PR TITLE
Update to Quarkus 0.21.1

### DIFF
--- a/environments/openshift-3-11/scripts/12_quarkus-setup.sh
+++ b/environments/openshift-3-11/scripts/12_quarkus-setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-GRAALVM_ARCHIVE='https://github.com/oracle/graal/releases/download/vm-1.0.0-rc13/graalvm-ce-1.0.0-rc13-linux-amd64.tar.gz'
-GRAALVM_BASENAME='graalvm-ce-1.0.0-rc13'
+GRAALVM_ARCHIVE='https://github.com/oracle/graal/releases/download/vm-19.1.1/graalvm-ce-linux-amd64-19.1.1.tar.gz'
+GRAALVM_BASENAME='graalvm-ce-19.1.1'
 
 echo "install gcc and deps"
 yum --enablerepo=extras install epel-release -y
@@ -12,22 +12,23 @@ wget $GRAALVM_ARCHIVE -O /tmp/graalvm.tar.gz
 tar -C /usr/local -xzf /tmp/graalvm.tar.gz
 echo "export GRAALVM_HOME=/usr/local/$GRAALVM_BASENAME" >> ~/.bashrc
 . ~/.bashrc
+${GRAALVM_HOME}/bin/gu install native-image
 
 # pre-populate maven repos by building a sample project
 TMPDIR=$(mktemp -d)
 pushd $TMPDIR
-mvn io.quarkus:quarkus-maven-plugin:0.12.0:create \
+mvn io.quarkus:quarkus-maven-plugin:0.21.1:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=getting-started \
     -DclassName="org.acme.quickstart.GreetingResource" \
     -Dpath="/hello"
 
 mvn -q -fn dependency:resolve-plugins dependency:resolve \
-    dependency:go-offline clean compile package 
+    dependency:go-offline clean compile package -DskipTests
 
 # and once for the native image
 
 mvn -q -fn dependency:resolve-plugins dependency:resolve \
-    dependency:go-offline clean compile package -Pnative
+    dependency:go-offline clean compile package  -DskipTests -Pnative
 
 popd

--- a/middleware/middleware-quarkus/getting-started/01-create-project.md
+++ b/middleware/middleware-quarkus/getting-started/01-create-project.md
@@ -6,7 +6,7 @@ In this step, you will create a straightforward application serving a `hello` en
 
 The easiest way to create a new Quarkus project is to click to run the following command:
 
-`mvn io.quarkus:quarkus-maven-plugin:0.12.0:create \
+`mvn io.quarkus:quarkus-maven-plugin:0.21.1:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=getting-started \
     -DclassName="org.acme.quickstart.GreetingResource" \

--- a/middleware/middleware-quarkus/getting-started/04-build-native.md
+++ b/middleware/middleware-quarkus/getting-started/04-build-native.md
@@ -60,7 +60,7 @@ Since our environment here is Linux, you can _just run it_:
 Notice the amazingly fast startup time:
 
 ```console
-2019-03-07 18:34:16,642 INFO  [io.quarkus] (main) Quarkus 0.11.0 started in 0.004s. Listening on: http://127.0.0.1:8080
+2019-03-07 18:34:16,642 INFO  [io.quarkus] (main) Quarkus 0.21.1 started in 0.004s. Listening on: http://[::]:8080
 2019-03-07 18:34:16,643 INFO  [io.quarkus] (main) Installed features: [cdi, resteasy]
 ```
 That's 4 milliseconds. A _mere 4000 nanoseconds_. 

--- a/middleware/middleware-quarkus/getting-started/05-deploy-to-openshift.md
+++ b/middleware/middleware-quarkus/getting-started/05-deploy-to-openshift.md
@@ -24,7 +24,7 @@ step. Click in the first terminal and press CTRL-C to stop the application and t
 
 ## Access OpenShift Project
 
-[Projects](https://docs.openshift.com/container-platform/3.6/architecture/core_concepts/projects_and_users.html#projects)
+[Projects](https://docs.openshift.com/container-platform/3.11/architecture/core_concepts/projects_and_users.html#projects)
 are a top level concept to help you organize your deployments. An
 OpenShift project allows a community of users (or a user) to organize and manage
 their content in isolation from other communities. 

--- a/middleware/middleware-quarkus/getting-started/set-env.sh
+++ b/middleware/middleware-quarkus/getting-started/set-env.sh
@@ -2,6 +2,6 @@
 cd projects
 mkdir -p quarkus
 cd quarkus
-export GRAALVM_HOME=/usr/local/graalvm-ce-1.0.0-rc13
-echo 'export GRAALVM_HOME=/usr/local/graalvm-ce-1.0.0-rc13' >> ~/.bashrc
+export GRAALVM_HOME=/usr/local/graalvm-ce-19.1.1
+echo 'export GRAALVM_HOME=/usr/local/graalvm-ce-19.1.1' >> ~/.bashrc
 clear

--- a/middleware/middleware-quarkus/panache/01-define-entity.md
+++ b/middleware/middleware-quarkus/panache/01-define-entity.md
@@ -14,11 +14,11 @@ We need to add a few extensions to the app for Panache and Postgres. We'll use t
 
 Click this command to add the Hibernate ORM with Panache extension:
 
-`mvn quarkus:add-extension -Dextensions="io.quarkus:quarkus-hibernate-orm-panache"`{{execute}}
+`mvn quarkus:add-extension -Dextensions="panache"`{{execute}}
 
 And then for Postgres:
 
-`mvn quarkus:add-extension -Dextensions="io.quarkus:quarkus-jdbc-postgresql"`{{execute}}
+`mvn quarkus:add-extension -Dextensions="jdbc-postgresql"`{{execute}}
 
 Done!
 


### PR DESCRIPTION
@BenHall - this PR updates the `environments/openshift-3-11` scripts to use the latest Quarkus and GraalVM. The base `openshift-3-11` image will need to be rebuilt and put into prod before this code can be merged. Happy to test things out if you can re-build in a non-prod environment.