### PR TITLE
Excluded the folders bin and pkg from the tree view

### DIFF
--- a/operatorframework/go-operator-podset/index.json
+++ b/operatorframework/go-operator-podset/index.json
@@ -46,7 +46,8 @@
     "uilayout": "editor-terminal",
     "uieditorpath": "/root/tutorial",
     "showdashboard": true,
-    "dashboard": "Dashboard"
+    "dashboard": "Dashboard",
+    "exclusionPatterns": ["./go/bin*", "./go/pkg*"]
   },
   "backend": {
     "imageid": "openshift-3-11",


### PR DESCRIPTION
Excluded the folders bin and pkg from the tree view to reducing the memory used in the scenario (#517).

Signed-off-by: Gabriela S. Soria <soria.gaby@gmail.com>