### PR TITLE
Fix: awk instruction for oc get svc

### DIFF
--- a/subsystems/container-internals-lab-2-0-part-5/01-multi-container-applications.md
+++ b/subsystems/container-internals-lab-2-0-part-5/01-multi-container-applications.md
@@ -97,6 +97,6 @@ Here are some useful locations to investigate what is happening. The "Events" se
 
 Finally, ensure that the web interface is up and running. We will need this for the next lab:
 
-``curl http://$(oc get svc | grep wpfrontend | awk '{print $2}')/wp-admin/install.php``{{execute}}
+``curl http://$(oc get svc | grep wpfrontend | awk '{print $3}')/wp-admin/install.php``{{execute}}
 
 In this exercise you learned how to deploy a fully functional two tier application with a single command (oc create). As long as the cluster has persistent volumes available to satisify the application, an end user can do this on their laptop, in a development environment or in production data centers all over the world. All of the dependent code is packaged up and delivered in the container images - all of the data and configuration comes from the environment. Production instances will access production persistent volumes, development environments can be seeded with copies of production data, etc. It's easy to see why container orchestration is so powerful. 

--- a/subsystems/container-internals-lab-2-0-part-5/02-load-testing.md
+++ b/subsystems/container-internals-lab-2-0-part-5/02-load-testing.md
@@ -2,7 +2,7 @@ In this exercise, you will scale and load test a distributed application.
 
 First, lets set up a variable so that we have the site name saved:
 
-``export SITE="http://$(oc get svc | grep wpfrontend | awk '{print $2}')/wp-admin/install.php"``{{execute}}
+``export SITE="http://$(oc get svc | grep wpfrontend | awk '{print $3}')/wp-admin/install.php"``{{execute}}
 
 Test with AB before we scale the application to get a base line. Take note of the "Time taken for tests" section:
 

--- a/subsystems/container-internals-lab-2-0-part-5/03-troubleshooting-distributed-applications.md
+++ b/subsystems/container-internals-lab-2-0-part-5/03-troubleshooting-distributed-applications.md
@@ -38,7 +38,7 @@ Get the IP address for the goodbad service
 
 Now test the cluster IP with curl. Use the cluster IP address so that the traffic is balanced among the active pods. You will notice some errors in your responses. You may also test with a browser. Some of the pods are different - how could this be? They should be identical because they were built from code right?
 
-``SVC_IP=$(oc get svc | grep goodbad | awk '{print $2}')
+``SVC_IP=$(oc get svc | grep goodbad | awk '{print $3}')
 for i in {1..20}; do curl $SVC_IP; done``{{execute}}
 
 


### PR DESCRIPTION
Relates to issue #577

Fixes incorrect awk commands. Currently isolates the type, i.e. ClusterIp, LoadBalance, instead of returning the cluster ip.