### PR TITLE
Remove extra commands, fix typos

### DIFF
--- a/servicemesh/4-simple-routerules/1modify-recommendation.md
+++ b/servicemesh/4-simple-routerules/1modify-recommendation.md
@@ -12,7 +12,7 @@ Open `/recommendation/java/vertx/src/main/java/com/redhat/developer/demos/recomm
 
 Now go to the recommendations folder `cd ~/projects/istio-tutorial/recommendation/java/vertx`{{execute T1}}
 
-Make sure that the file has changed: `git diff`{{execute T1}}. To exit, hit `q`{{execute T1}}
+Make sure that the file has changed: `git diff`{{execute T1}}.
 
 Compile the project with the modifications that you did.
 

--- a/servicemesh/8-egress/1create-recommendation-v3.md
+++ b/servicemesh/8-egress/1create-recommendation-v3.md
@@ -23,7 +23,7 @@ and remove the comment the call to get the actual time.
 
 Now go to the recommendations folder `cd ~/projects/istio-tutorial/recommendation/java/vertx`{{execute T1}}
 
-Make sure that the file has changed: `git diff`{{execute T1}}. To exit, hit `q`{{execute T1}}
+Make sure that the file has changed: `git diff`{{execute T1}}.
 
 Compile the project with the modifications that you did.
 

--- a/servicemesh/8-egress/2istioize-egress.md
+++ b/servicemesh/8-egress/2istioize-egress.md
@@ -16,7 +16,7 @@ Let’s fix it by registering a service entry to allow access to httpbin.
 
 Open the file `istiofiles/service-entry-egress-worldclockapi.yml`{{open}}.
 
-Note that this `ServiceEntry` allows you to access the host `now.httpbin.org` in the port `80`.
+Note that this `ServiceEntry` allows you to access the host `worldclockapi.com` in the port `80`.
 
 Apply this file executing the following command:
 

--- a/servicemesh/8-egress/2istioize-egress.md
+++ b/servicemesh/8-egress/2istioize-egress.md
@@ -1,4 +1,4 @@
-Let’s redirect all traffic to reccomendation:v3.
+Let’s redirect all traffic to recommendation:v3.
 
 `istioctl create -f ~/projects/istio-tutorial/istiofiles/destination-rule-recommendation-v1-v2-v3.yml -n tutorial; \
 istioctl create -f ~/projects/istio-tutorial/istiofiles/virtual-service-recommendation-v3.yml
@@ -18,7 +18,7 @@ Open the file `istiofiles/service-entry-egress-worldclockapi.yml`{{open}}.
 
 Note that this `ServiceEntry` allows you to access the host `now.httpbin.org` in the port `80`.
 
-Applye this file executing the following command:
+Apply this file executing the following command:
 
 `istioctl create -f ~/projects/istio-tutorial/istiofiles/service-entry-egress-worldclockapi.yml -n tutorial`{{execute T1}}
 

--- a/servicemesh/adv2-mTLS/1before-start.md
+++ b/servicemesh/adv2-mTLS/1before-start.md
@@ -11,7 +11,7 @@ Then configure some environment variables that will help you on testing:
 `export INGRESS_PORT=$(oc -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="http2")].nodePort}'); \
 export GATEWAY_URL=http://customer-tutorial.[[HOST_SUBDOMAIN]]-$INGRESS_PORT-[[KATACODA_HOST]].environments.katacoda.com; `{{execute T1}}
 
-Now you can run curl but against GATEWAY_URL and you’ll see the same messages as before (customer => preference => recommendation v1 from 'b87789c58-mfrhr': 1):
+Now you can run curl but against GATEWAY_URL and you’ll see the same messages as before (`customer => preference => recommendation v1 from 'b87789c58-mfrhr': 1`):
 
 `curl ${GATEWAY_URL}`{{execute T1}}
 


### PR DESCRIPTION
Just going through these workshops. Minor changes detailed below. ~, but I don't get a pager when checking the `git diff` so I think we can remove this piece here. Not sure if the pager was in place previously and the behavior changed.~

EDIT: Adding a typo fix to this branch so relabeling title and this post for clarity.

`remove q to exit git diff pager` Fixes:
*  Removes a command to exit the git diff pager where a pager does not come up in 2 files.

`fixing a typo` Fixes:
*  a typo _reccomendation_ to _recommendation_ in 1 file.
* a typo _Applye_ to _Apply_ in 1 file.

`update tasks to replace now.httpbin.org with worldclockapi.com` Fixes #612 

`add preformatted text markers for clarity` fixes
* a section in adv2-mtls/1before-start.md which represents output but was not enclosed in backticks.