### PR TITLE
URL fix for fedora-toolbox

### DIFF
--- a/subsystems/container-internals-lab-2-0-part-7/01-podman.md
+++ b/subsystems/container-internals-lab-2-0-part-7/01-podman.md
@@ -47,7 +47,7 @@ The above commands show how easy and elegant podman is to use. Now, lets analyse
 
 Cache the Fedora Toolbox image:
 
-``podman pull registry.fedoraproject.org/f28/fedora-toolbox``{{execute}}
+``podman pull registry.fedoraproject.org/f29/fedora-toolbox``{{execute}}
 
 Wait for the image pull to complete, then move on...
 


### PR DESCRIPTION
Seems like the registry of Fedora isn't offering the f28 anymore ... tested with f29 worked