### PR TITLE
[env/4.2] pre-pull image OpenDataHub Operator Image

### DIFF
--- a/environments/openshift-4-2/master/build/5_odh-pull.sh
+++ b/environments/openshift-4-2/master/build/5_odh-pull.sh
@@ -1,0 +1,1 @@
+sudo podman pull quay.io/opendatahub/opendatahub-operator:v0.5.1


### PR DESCRIPTION
This should pre-pull required images by the odh operator to improve the environment set up times.
