### PR TITLE
index.json and set-env.sh: Fix file spec for deploy-prometheus.yaml

### DIFF
--- a/introduction/deploy-prometheus-grafana/index.json
+++ b/introduction/deploy-prometheus-grafana/index.json
@@ -42,7 +42,7 @@
             "text": "finish.md"
         },
         "assets": {
-          "host01": [{"file": "deploy-prometheus.yaml", "target": "~/"}]
+          "client": [{"file": "deploy-prometheus.yaml", "target": "~"}]
         }
     }
 }

--- a/introduction/deploy-prometheus-grafana/set-env.sh
+++ b/introduction/deploy-prometheus-grafana/set-env.sh
@@ -12,7 +12,7 @@ oc expose svc/metrics-demo-app
 # oc create -f ~/volumes.json --as system:admin > /dev/null 2>&1
 #
 oc new-project pad-monitoring
-oc process -f deploy-prometheus.yaml | oc apply -n pad-monitoring -f -
+oc process -f ~/deploy-prometheus.yaml | oc apply -n pad-monitoring -f -
 oc import-image grafana/grafana:6.6.1 --confirm
 
 clear


### PR DESCRIPTION
It seems like the index.json asset file spec doesn't like the
trailing slash on ~ or other target directories. This actually
resolved the missing `deploy-prometheus.yaml`.

Also s/host01/client/ to match other scenarios' asset file specs.(?)

Fixes #820
Fixes #817 
Fixes #800 