### PR TITLE
Redirect /operators to /operatorframework

### DIFF
--- a/branded-ui/katacoda/redirect.go
+++ b/branded-ui/katacoda/redirect.go
@@ -10,6 +10,7 @@ func getRedirectUrl(course string, scenario string) string {
     "introduction/rhoar-getting-started-wfswarm": "/middleware/rhoar-getting-started-wfswarm",
     "introduction/rhoar-getting-started-spring": "/middleware/rhoar-getting-started-spring",
     "introduction/rhoar-getting-started-vertx": "/middleware/rhoar-getting-started-vertx",
+    "operators": "operatorframework",
   }
 
   return oldScenarios[course + "/" + scenario]


### PR DESCRIPTION
Please try this to create the redirect for https://learn.openshift.com/operators to
https://learn.openshift.com/operatorframework.

This is in response to a request to the Katacoda support team.