### PR TITLE
Set redirect from /operators to /operatorframework

### DIFF
--- a/redirect.json
+++ b/redirect.json
@@ -2,5 +2,6 @@
   {"course": "intro-openshift", "targetCourse": "introduction"},
   {"course": "middleware", "scenario": "resilient-apps", "targetCourse": "servicemesh", "targetScenario": "istio-fasttrack"},
   {"course": "middleware", "scenario": "rhoar-getting-started-spring", "targetCourse": "middleware", "targetScenario": "middleware-spring-boot/spring-getting-started"},
-  {"course": "middleware", "scenario": "rhoar-getting-started-vertx", "targetCourse": "middleware", "targetScenario": "middleware-vertx/getting-started-vertx"}
+  {"course": "middleware", "scenario": "rhoar-getting-started-vertx", "targetCourse": "middleware", "targetScenario": "middleware-vertx/getting-started-vertx"},
+  {"course": "operators", "targetCourse": "operatorframework"}
 ]


### PR DESCRIPTION
This is an additional setting needed for the redirect to work.