### PR TITLE
redirect cicd app delivery to gitops

### DIFF
--- a/cicd-application-delivery-pathway.json
+++ b/cicd-application-delivery-pathway.json
@@ -1,0 +1,30 @@
+{
+    "title": "GitOps and Pipelines with OpenShift",
+    "icon": "fa-openshift",
+    "courses": [
+      {
+       "external_link": "https://learn.openshift.com/middleware/pipelines/",
+       "pathway_id": "middleware",
+       "course_id": "pipelines",
+       "title": "Using OpenShift Pipelines"
+      },
+      {
+        "external_link": "https://learn.openshift.com/gitops/getting-started/",
+        "pathway_id": "gitops",
+        "course_id": "getting-started",
+        "title": "Getting Started with ArgoCD and OpenShift GitOps Operator"
+      },
+      {
+        "external_link": "https://learn.openshift.com/gitops/kustomize/",
+        "pathway_id": "gitops",
+        "course_id": "kustomize",
+        "title": "Working with Kustomize"
+      },
+      {
+        "external_link": "https://learn.openshift.com/gitops/syncwaves-and-hooks/",
+        "pathway_id": "gitops",
+        "course_id": "syncwaves-hooks",
+        "title": "Syncwaves and Hooks"
+      }
+    ]
+}

--- a/redirect.json
+++ b/redirect.json
@@ -3,6 +3,5 @@
   {"course": "middleware", "scenario": "resilient-apps", "targetCourse": "servicemesh", "targetScenario": "istio-fasttrack"},
   {"course": "middleware", "scenario": "rhoar-getting-started-spring", "targetCourse": "middleware", "targetScenario": "middleware-spring-boot/spring-getting-started"},
   {"course": "middleware", "scenario": "rhoar-getting-started-vertx", "targetCourse": "middleware", "targetScenario": "middleware-vertx/getting-started-vertx"},
-  {"course": "cicd-application-delivery", "targetCourse": "gitops"},
   {"course": "operators", "targetCourse": "operatorframework"}
 ]


### PR DESCRIPTION
the "redirect" method worked on my personal katacoda, but not learn., so maybe something else is going on.  just copied the GitOps.json over to cicd-app-delivery