### PR TITLE
Added a "git pull.." in set-env.sh to update static old version of 'master' branch

### DIFF
--- a/middleware/middleware-spring-boot/spring-getting-started/set-env.sh
+++ b/middleware/middleware-spring-boot/spring-getting-started/set-env.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 cd projects/rhoar-getting-started/spring/spring-rhoar-intro
 ~/.launch.sh
-
+# To update the static old version of the repo
+git pull origin master


### PR DESCRIPTION
A static copy of the repo/master is possibly bundled into **openshift-middleware-3-7** image. The static old repo points to SpringBoot-BOM 1.5.15 whereas the latest version in master points to 2.1.6.

The `git pull origin master` fetches the latest changes from master.
