### PR TITLE
bump JavaEE8 from 4-6 to 4-7

### DIFF
--- a/middleware-pathway.json
+++ b/middleware-pathway.json
@@ -30,7 +30,7 @@
     },
     {
       "action": "Start Course",
-      "coount": 3,
+      "count": 3,
       "external_link": "https://learn.openshift.com/middleware/courses/middleware-kogito/",
       "course_id": "middleware-kogito",
       "title": "Developing with Kogito"

--- a/middleware/middleware-javaee8/index.json
+++ b/middleware/middleware-javaee8/index.json
@@ -52,7 +52,7 @@
     },
     "backend": {
         "autoUpgrade": true,
-        "imageid": "openshift-4-6",
+        "imageid": "openshift-4-7",
         "port": 8443
     }
 }


### PR DESCRIPTION
Updated to `openshift-4-7`:
- [x] [Red Hat Data Grid development](https://learn.openshift.com/middleware/rhoar-getting-started-rhdg/)

related: #1060