### PR TITLE
Provide scenario outro with ability to fork solution to user's own repo and link solution to Red Hat Dev Sandbox

### DIFF
--- a/assets/middleware/install-github-cli.sh
+++ b/assets/middleware/install-github-cli.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+GH_CLI_VERSION=1.13.1
+GH_CLI_NM=gh_${GH_CLI_VERSION}_linux_amd64
+GH_CLI_FILE_NM=${GH_CLI_NM}.tar.gz
+
+export GH_CLI_HOME="/usr/local/$GH_CLI_NM" && \
+export PATH=$GH_CLI_HOME/bin:$PATH && \
+echo "export GH_CLI_HOME=$GH_CLI_HOME" >> ~/.bashrc && \
+echo "export PATH=$GH_CLI_HOME/bin:\$PATH" >> ~/.bashrc
+
+curl -w '' -sL https://github.com/cli/cli/releases/download/v$GH_CLI_VERSION/$GH_CLI_FILE_NM | \
+  ( cd /usr/local; tar -xvzf - )

--- a/assets/middleware/install-graalvm.sh
+++ b/assets/middleware/install-graalvm.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
-GRAAL_VERSION=21.0.0.2
-curl -w '' -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-java11-linux-amd64-{$GRAAL_VERSION}.tar.gz | \
-  ( cd /usr/local; tar -xvzf - ) && \
-export GRAALVM_HOME="/usr/local/graalvm-ce-java11-${GRAAL_VERSION}" && \
-export PATH=$GRAALVM_HOME/bin:$PATH && \
-$GRAALVM_HOME/bin/gu install native-image && \
-echo "export GRAALVM_HOME=$GRAALVM_HOME" >> ~/.bashrc && \
-echo "export PATH=$GRAALVM_HOME/bin:\$PATH" >> ~/.bashrc
+GRAAL_VERSION=21.0.0.0
+
+# export GRAALVM_HOME="/usr/local/graalvm-ce-java11-${GRAAL_VERSION}" && \
+export MANDREL_HOME="/usr/local/mandrel-java11-${GRAAL_VERSION}-Final" && \
+export GRAALVM_HOME="${MANDREL_HOME}" && \
+export PATH=$MANDREL_HOME/bin:$PATH && \
+echo "export MANDREL_HOME=$MANDREL_HOME" >> ~/.bashrc && \
+echo "export GRAALVM_HOME=$MANDREL_HOME" >> ~/.bashrc && \
+echo "export PATH=$MANDREL_HOME/bin:\$PATH" >> ~/.bashrc
+
+# curl -w '' -sL https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-${GRAAL_VERSION}/graalvm-ce-java11-linux-amd64-${GRAAL_VERSION}.tar.gz | \
+yum install glibc-devel zlib-devel gcc freetype-devel libstdc++ glibc -y && \
+curl -w '' -sL https://github.com/graalvm/mandrel/releases/download/mandrel-${GRAAL_VERSION}-Final/mandrel-java11-linux-amd64-${GRAAL_VERSION}-Final.tar.gz | \
+  ( cd /usr/local; tar -xvzf - )
+# $GRAALVM_HOME/bin/gu install native-image

--- a/assets/middleware/install-openjdk.sh
+++ b/assets/middleware/install-openjdk.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-curl -w '' -sL https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10+9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz | \
-  ( cd /usr/local; tar -xvzf - ) && \
 export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
 export PATH=$JAVA_HOME/bin:$PATH && \
 echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
 echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc
 
-
-
+curl -w '' -sL https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10+9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz | \
+  ( cd /usr/local; tar -xvzf - )

--- a/assets/middleware/run-gh-fork.sh
+++ b/assets/middleware/run-gh-fork.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+gh auth login --web
+gh repo fork openshift-katacoda/rhoar-getting-started --clone=false
+gh auth logout

--- a/assets/middleware/setup-xdg-open.sh
+++ b/assets/middleware/setup-xdg-open.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mv /usr/bin/xdg-open /usr/bin/xdg-open.orig
+echo '#!/bin/bash' > /usr/bin/xdg-open
+echo "./xdg-open.orig $@ > /dev/null 2>/dev/null" >> /usr/bin/xdg-open
+chmod +x /usr/bin/xdg-open

--- a/middleware/middleware-quarkus/getting-started/06-scaling.md
+++ b/middleware/middleware-quarkus/getting-started/06-scaling.md
@@ -48,6 +48,25 @@ And witness all 50 pods responding evenly to requests. Try doing that with your 
 
 > 50 still not enough? Are you feeling lucky? Try **100**: `oc scale --replicas=100 dc/getting-started`{{execute T1}} and watch the magic on the [OpenShift Console](https://[[HOST_SUBDOMAIN]]-8443-[[KATACODA_HOST]].environments.katacoda.com/console/project/quarkus/overview). It may take a bit of time for all 100 to spin up given this limited resource environment, but they will eventually!
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/quarkus/getting-started/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `getting-started` project inside the `quarkus` folder contains the completed solution for this scenario.
+
 ## Congratulations
 
 In this scenario you got a glimpse of the power of Quarkus apps, both traditional JVM-based as well as native builds. There is much more to Quarkus than fast startup times and low resource usage, so keep on exploring additional scenarios to learn more, and be sure to visit [quarkus.io](https://quarkus.io) to learn even more about the architecture and capabilities of this exciting new framework for Java developers.

--- a/middleware/middleware-quarkus/getting-started/env-init.sh
+++ b/middleware/middleware-quarkus/getting-started/env-init.sh
@@ -1,2 +1,21 @@
+#!/bin/bash
 mkdir -p /root/projects/quarkus
+
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-graalvm.sh > /tmp/graalvm.sh
+
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /tmp/graalvm.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh
+/tmp/graalvm.sh
+
 echo "-w \"\n\"" >> ~/.curlrc

--- a/middleware/middleware-quarkus/getting-started/set-env.sh
+++ b/middleware/middleware-quarkus/getting-started/set-env.sh
@@ -3,25 +3,16 @@
 mkdir -p /root/projects/quarkus
 cd /root/projects/quarkus
 
-wget -O /tmp/graalvm.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.0.0.2/graalvm-ce-java11-linux-amd64-21.0.0.2.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/graalvm.tar.gz && \
-rm -rf /tmp/graalvm.tar.gz && \
-export GRAALVM_HOME="/usr/local/graalvm-ce-java11-21.0.0.2" && \
-export PATH=$GRAALVM_HOME/bin:$PATH && \
-$GRAALVM_HOME/bin/gu install native-image && \
-echo "export GRAALVM_HOME=$GRAALVM_HOME" >> ~/.bashrc && \
-echo "export PATH=$GRAALVM_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
-
-wget -O /tmp/jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/jdk.tar.gz && \
-rm -rf /tmp/jdk.tar.gz && \
-export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
-export PATH=$JAVA_HOME/bin:$PATH && \
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
-
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo Installing the latest GraalVM runtime..' >> /tmp/launch.sh
+echo 'until ${MANDREL_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'export GRAALVM_HOME=$MANDREL_HOME >> ~/.bashrc' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-quarkus/kafka/07-deploy-and-test.md
+++ b/middleware/middleware-quarkus/kafka/07-deploy-and-test.md
@@ -86,6 +86,25 @@ So now our app is deployed to OpenShift. Finally, let's confirm our streaming Ka
 
 ![kafka](/openshift/assets/middleware/quarkus/wordcloud.png)
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/quarkus/kafka/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `kafka` project inside the `quarkus` folder contains the completed solution for this scenario.
+
 ## Congratulations!
 
 This guide has shown how you can interact with Kafka using Quarkus. It utilizes MicroProfile Reactive Messaging to build

--- a/middleware/middleware-quarkus/kafka/env-init.sh
+++ b/middleware/middleware-quarkus/kafka/env-init.sh
@@ -1,12 +1,17 @@
+#!/bin/bash
 mkdir -p /root/projects/rhoar-getting-started/quarkus/kafka
 echo "-w \"\n\"" >> ~/.curlrc
 
-wget -O /tmp/jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/jdk.tar.gz && \
-rm -rf /tmp/jdk.tar.gz && \
-export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
-export PATH=$JAVA_HOME/bin:$PATH && \
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
+
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-quarkus/kafka/set-env.sh
+++ b/middleware/middleware-quarkus/kafka/set-env.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
-export JAVA_HOME="/usr/local/jdk-11.0.10+9"
-export PATH=$JAVA_HOME/bin:$PATH
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-quarkus/monitoring/02-create-and-instrument-app.md
+++ b/middleware/middleware-quarkus/monitoring/02-create-and-instrument-app.md
@@ -18,7 +18,8 @@ If the command fails, wait a few moments and try again (it is installed in a bac
 
 Let's create the basic Quarkus _Hello World_ application and include the necessary monitoring extensions. Click this command to create the project:
 
-`mvn io.quarkus:quarkus-maven-plugin:2.0.0.Final:create \
+`cd /root/projects/quarkus && \
+mvn io.quarkus:quarkus-maven-plugin:2.0.0.Final:create \
     -DprojectGroupId=org.acme \
     -DprojectArtifactId=primes \
     -DclassName="org.acme.quickstart.GreetingResource" \

--- a/middleware/middleware-quarkus/monitoring/07-create-dashboard.md
+++ b/middleware/middleware-quarkus/monitoring/07-create-dashboard.md
@@ -73,6 +73,25 @@ Click **Save Dashboad** again to save it. Your final Dashboard should look like:
 
 You can add many more metrics to monitor and alert for Quarkus apps using these tools.
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/quarkus/monitoring/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `monitoring` project inside the `quarkus` folder contains the completed solution for this scenario.
+
 # Congratulations\!
 
 This exercise demonstrates how your Quarkus application can utilize the [Micrometer

--- a/middleware/middleware-quarkus/monitoring/env-init.sh
+++ b/middleware/middleware-quarkus/monitoring/env-init.sh
@@ -1,9 +1,19 @@
+#!/bin/bash
 mkdir -p /root/projects/quarkus
 yum -y install openssl
 
 echo "-w \"\n\"" >> ~/.curlrc
 
 curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
 
 chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
 /tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-quarkus/monitoring/set-env.sh
+++ b/middleware/middleware-quarkus/monitoring/set-env.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-
-mkdir -p /root/projects/quarkus
-cd /root/projects/quarkus
-mkdir -p /root/.m2
-export JAVA_HOME="/usr/local/jdk-11.0.10+9"
-export PATH=$JAVA_HOME/bin:$PATH
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-quarkus/panache-reactive/06-exercise-table.md
+++ b/middleware/middleware-quarkus/panache-reactive/06-exercise-table.md
@@ -10,14 +10,33 @@ Notice the total number of records reported at the bottom. Type in a single lett
 
 Skip around a few pages, try some different searches, and notice that the data is only loaded when needed. The overall performance is very good even for low-bandwidth connections or huge data sets.
 
-## Congratulations
+When you are done, return to the first Terminal, press `CTRL-C` to stop the running Quarkus app (or click the `clear`{{execute T1 interrupt}} command to do it for you).
 
+# Extra Credit
+There are [many other features of DataTables](https://datatables.net/manual/server-side) that could be supported on the server side with Quarkus and Panache. For example, when our endpoint is accessed, the set of columns to order on is also passed using the `order` and `columns` arrays, which we do not cover in this scenario. If you have time, try to add additional code to support these incoming parameters and order the resulting records accordingly!
+
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/quarkus/panache-reactive/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `panache-reactive` project inside the `quarkus` folder contains the completed solution for this scenario.
+
+## Congratulations
 In this scenario you got a glimpse of the power of Quarkus apps when dealing with large amounts of data.
 
 You also got to experience Quarkus Remote Development, where local changes are immediately reflected in remote applications. You deployed the app to OpenShift and live-coded changes on the fly.
 
 There is much more to Quarkus than this, so keep on exploring additional scenarios to learn more, and be sure to visit [quarkus.io](https://quarkus.io) to learn even more about the architecture and capabilities of this exciting new framework for Java developers.
-
-# Extra Credit
-
-There are [many other features of DataTables](https://datatables.net/manual/server-side) that could be supported on the server side with Quarkus and Panache. For example, when our endpoint is accessed, the set of columns to order on is also passed using the `order` and `columns` arrays, which we do not cover in this scenario. If you have time, try to add additional code to support these incoming parameters and order the resulting records accordingly!

--- a/middleware/middleware-quarkus/panache-reactive/env-init.sh
+++ b/middleware/middleware-quarkus/panache-reactive/env-init.sh
@@ -1,8 +1,17 @@
+#!/bin/bash
 mkdir -p /root/projects/rhoar-getting-started/quarkus/panache-reactive
 yum install tree -y
 
 curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
 
 chmod a+x /tmp/jdk.sh
-/tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
 
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-quarkus/panache-reactive/set-env.sh
+++ b/middleware/middleware-quarkus/panache-reactive/set-env.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
-export JAVA_HOME="/usr/local/jdk-11.0.10+9"
-export PATH=$JAVA_HOME/bin:$PATH
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc
 clear
 echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
-echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n .; done' >> /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
 echo 'echo' >> /tmp/launch.sh
 echo 'echo "Ready!"' >> /tmp/launch.sh
 chmod a+x /tmp/launch.sh
 clear
 /tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-quarkus/panache/06-exercise-table.md
+++ b/middleware/middleware-quarkus/panache/06-exercise-table.md
@@ -10,6 +10,25 @@ Notice the total number of records reported at the bottom. Type in a single lett
 
 Skip around a few pages, try some different searches, and notice that the data is only loaded when needed. The overall performance is very good even for low-bandwidth connections or huge data sets.
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/quarkus/panache/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `panache` project inside the `quarkus` folder contains the completed solution for this scenario.
+
 ## Congratulations
 
 In this scenario you got a glimpse of the power of Quarkus apps when dealing with large amounts of data.

--- a/middleware/middleware-quarkus/panache/env-init.sh
+++ b/middleware/middleware-quarkus/panache/env-init.sh
@@ -1,8 +1,17 @@
+#!/bin/bash
 mkdir -p /root/projects/rhoar-getting-started/quarkus/panache
 yum install tree -y
 
 curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
 
 chmod a+x /tmp/jdk.sh
-/tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
 
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-quarkus/panache/set-env.sh
+++ b/middleware/middleware-quarkus/panache/set-env.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
-export JAVA_HOME="/usr/local/jdk-11.0.10+9"
-export PATH=$JAVA_HOME/bin:$PATH
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc
 clear
 echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
-echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n .; done' >> /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
 echo 'echo' >> /tmp/launch.sh
 echo 'echo "Ready!"' >> /tmp/launch.sh
 chmod a+x /tmp/launch.sh
 clear
 /tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-quarkus/qute/06-reactive.md
+++ b/middleware/middleware-quarkus/qute/06-reactive.md
@@ -63,6 +63,25 @@ You should see a random report of the samples from earlier, but done so with a _
 
 To learn more about Quarkus and reactive programming, check out the [Reactive Programming with Quarkus Reactive SQL exercise](https://learn.openshift.com/middleware/courses/middleware-quarkus/reactive-sql).
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/quarkus/qute/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `qute` project inside the `quarkus` folder contains the completed solution for this scenario.
+
 # Wrap-up
 
 Congratulations! Qute provides a powerful, flexible, type-safe and reactive way to render templates using ideas and mechanisms familiar to Java developers. To learn more about Qute, please refer to the [Qute reference guide](https://quarkus.io/guides/qute-reference).

--- a/middleware/middleware-quarkus/qute/env-init.sh
+++ b/middleware/middleware-quarkus/qute/env-init.sh
@@ -1,8 +1,18 @@
+#!/bin/bash
 mkdir -p /root/projects/quarkus
 
 curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
 
 chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
 /tmp/jdk.sh
+/tmp/ghcli.sh
 
 echo "-w \"\\\n\"" >> ~/.curlrc

--- a/middleware/middleware-quarkus/qute/set-env.sh
+++ b/middleware/middleware-quarkus/qute/set-env.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
-export JAVA_HOME="/usr/local/jdk-11.0.10+9"
-export PATH=$JAVA_HOME/bin:$PATH
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc
 clear
 echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
-echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n .; done' >> /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
 echo 'echo' >> /tmp/launch.sh
 echo 'echo "Ready!"' >> /tmp/launch.sh
 chmod a+x /tmp/launch.sh
 clear
 /tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-quarkus/reactive-sql/05-package-and-run.md
+++ b/middleware/middleware-quarkus/reactive-sql/05-package-and-run.md
@@ -30,6 +30,24 @@ The output should end with `BUILD SUCCESS`.
 
 ![Reactive SQL app UI](/openshift/assets/middleware/quarkus/reactive-sql-ui.png)
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/quarkus/reactive-sql/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `reactive-sql` project inside the `quarkus` folder contains the completed solution for this scenario.
 ## Congratulations!
 
 You've packaged up the app as a production app and learned a bit more about the mechanics of packaging. In this tutorial we also used JAX-RS and deployed our application to the Openshift Container platform.

--- a/middleware/middleware-quarkus/reactive-sql/env-init.sh
+++ b/middleware/middleware-quarkus/reactive-sql/env-init.sh
@@ -1,8 +1,18 @@
+#!/bin/bash
 mkdir -p /root/projects
 
 curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
 
 chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
 /tmp/jdk.sh
+/tmp/ghcli.sh
 
 echo "-w \"\\\n\"" >> ~/.curlrc

--- a/middleware/middleware-quarkus/reactive-sql/set-env.sh
+++ b/middleware/middleware-quarkus/reactive-sql/set-env.sh
@@ -1,13 +1,10 @@
 #!/bin/bash
-export JAVA_HOME="/usr/local/jdk-11.0.10+9"
-export PATH=$JAVA_HOME/bin:$PATH
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc
 clear
 echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
-echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n .; done' >> /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
 echo 'echo' >> /tmp/launch.sh
 echo 'echo "Ready!"' >> /tmp/launch.sh
 chmod a+x /tmp/launch.sh
 clear
 /tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-quarkus/spring/06-deploy-and-test.md
+++ b/middleware/middleware-quarkus/spring/06-deploy-and-test.md
@@ -156,6 +156,25 @@ Finally, scale it back down:
 
 `oc scale --replicas=1 dc/fruit-taster`{{execute T1}}
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/quarkus/spring/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `spring` project inside the `quarkus` folder contains the completed solution for this scenario.
+
 ## Congratulations!
 
 This step covered the deployment of a Quarkus application on OpenShift using Spring compatibility APIs. To try out the native features, try the Getting Started tutorial. There is much more, and the integration with these environments has been tailored to make Quarkus applications execution very smooth.

--- a/middleware/middleware-quarkus/spring/env-init.sh
+++ b/middleware/middleware-quarkus/spring/env-init.sh
@@ -1,13 +1,21 @@
+#!/bin/bash
 mkdir -p /root/projects/quarkus
 
 curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
-
-chmod a+x /tmp/jdk.sh
-/tmp/jdk.sh
-
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
 curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-graalvm.sh > /tmp/graalvm.sh
 
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
 chmod a+x /tmp/graalvm.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh
 /tmp/graalvm.sh
 
-echo "-w \"\\\n\"" >> ~/.curlrc
+echo "-w \"\n\"" >> ~/.curlrc

--- a/middleware/middleware-quarkus/spring/set-env.sh
+++ b/middleware/middleware-quarkus/spring/set-env.sh
@@ -1,23 +1,14 @@
 #!/bin/bash
-
-GRAAL_VERSION=21.0.0.2
-JAVA_VERSION=11.0.10+9
-
-export JAVA_HOME="/usr/local/jdk-${JAVA_VERSION}"
-export PATH=$JAVA_HOME/bin:$PATH
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc
-
-export GRAALVM_HOME="/usr/local/graalvm-ce-java11-${GRAAL_VERSION}"
-export PATH=$GRAALVM_HOME/bin:$PATH
-echo "export GRAALVM_HOME=$GRAALVM_HOME" >> ~/.bashrc
-echo "export PATH=$GRAALVM_HOME/bin:\$PATH" >> ~/.bashrc
-
 clear
 echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
-echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n .; done' >> /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo Installing the latest GraalVM runtime..' >> /tmp/launch.sh
+echo 'until ${MANDREL_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'export GRAALVM_HOME=$MANDREL_HOME >> ~/.bashrc' >> /tmp/launch.sh
 echo 'echo' >> /tmp/launch.sh
 echo 'echo "Ready!"' >> /tmp/launch.sh
 chmod a+x /tmp/launch.sh
 clear
 /tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-spring-boot/microservices-1/03-modify-the-configmap.md
+++ b/middleware/middleware-spring-boot/microservices-1/03-modify-the-configmap.md
@@ -34,6 +34,25 @@ Click [here](http://spring-boot-configmap-greeting-dev.[[HOST_SUBDOMAIN]]-80-[[K
 
 This means that we were able to modify our application behavior through External Configuration of the `application.properties` file using a ConfigMap without having to even take down the application. That's pretty powerful!
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/spring/microservices-externalized-config/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `microservices-externalized-config` project inside the `spring` folder contains the completed solution for this scenario.
+
 ## Congratulations
 
 You have now learned how to handle Externalized Configuration with ConfigMaps through OpenShift. By creating a `ConfigMap`, we're able to modify application properties on the fly and simply rollout the new changes to our application.

--- a/middleware/middleware-spring-boot/microservices-1/env-init.sh
+++ b/middleware/middleware-spring-boot/microservices-1/env-init.sh
@@ -1,2 +1,16 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/microservices-externalized-config
 echo "-w \"\n\"" >> ~/.curlrc
+
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
+
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-spring-boot/microservices-1/set-env.sh
+++ b/middleware/middleware-spring-boot/microservices-1/set-env.sh
@@ -3,15 +3,12 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/microservices-externalized-config
 cd /root/projects/rhoar-getting-started/spring/microservices-externalized-config
 
-# Install Java 11
-wget -O /tmp/jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/jdk.tar.gz && \
-rm -rf /tmp/jdk.tar.gz && \
-export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
-export PATH=$JAVA_HOME/bin:$PATH && \
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
-
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-spring-boot/monitoring/03-add-health-checks.md
+++ b/middleware/middleware-spring-boot/monitoring/03-add-health-checks.md
@@ -75,6 +75,25 @@ This will display different types of metric data about the JVM Metrics:
 
 In addition to the different monitoring endpoints we also have informational endpoints like the `/actuator/beans` endpoint [here](http://spring-monitoring-dev.[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/actuator/beans), which will show all of the configured beans in the application. Spring Actuator provides multiple informational endpoints on top of the monitoring endpoints that can prove useful for information gathering about your deployed Spring application and can be helpful while debugging your applications in OpenShift.
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/spring/spring-monitoring/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `spring-monitoring` project inside the `spring` folder contains the completed solution for this scenario.
+
 ## Congratulations
 
 You have now included a health check in your Spring Boot application that's living in the OpenShift Container Platform.

--- a/middleware/middleware-spring-boot/monitoring/env-init.sh
+++ b/middleware/middleware-spring-boot/monitoring/env-init.sh
@@ -1,2 +1,16 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-monitoring
 echo "-w \"\n\"" >> ~/.curlrc
+
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
+
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-spring-boot/monitoring/set-env.sh
+++ b/middleware/middleware-spring-boot/monitoring/set-env.sh
@@ -3,15 +3,12 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-monitoring
 cd /root/projects/rhoar-getting-started/spring/spring-monitoring
 
-# Install Java 11
-wget -O /tmp/jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/jdk.tar.gz && \
-rm -rf /tmp/jdk.tar.gz && \
-export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
-export PATH=$JAVA_HOME/bin:$PATH && \
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
-
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-spring-boot/spring-db-access/03-deploy-to-openshift.md
+++ b/middleware/middleware-spring-boot/spring-db-access/03-deploy-to-openshift.md
@@ -72,6 +72,25 @@ Then either go to the OpenShift web console and click on the route or click [her
 
 Make sure that you can add and remove fruits using the web application.
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/spring/spring-db-access/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `spring-db-access` project inside the `spring` folder contains the completed solution for this scenario.
+
 ## Congratulations
 
 You have now learned how to deploy a Spring Boot application to OpenShift Container Platform with a PostgreSQL database. Click Summary for more details and suggested next steps.

--- a/middleware/middleware-spring-boot/spring-db-access/env-init.sh
+++ b/middleware/middleware-spring-boot/spring-db-access/env-init.sh
@@ -1,2 +1,16 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-db-access
 echo "-w \"\n\"" >> ~/.curlrc
+
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
+
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-spring-boot/spring-db-access/set-env.sh
+++ b/middleware/middleware-spring-boot/spring-db-access/set-env.sh
@@ -3,15 +3,12 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-db-access
 cd /root/projects/rhoar-getting-started/spring/spring-db-access
 
-# Install Java 11
-wget -O /tmp/jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/jdk.tar.gz && \
-rm -rf /tmp/jdk.tar.gz && \
-export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
-export PATH=$JAVA_HOME/bin:$PATH && \
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
-
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-spring-boot/spring-getting-started/05-deploy-to-openshift.md
+++ b/middleware/middleware-spring-boot/spring-getting-started/05-deploy-to-openshift.md
@@ -63,6 +63,25 @@ Then either go to the openshift web console and click on the route or click [her
 
 Make sure that you can add, edit, and remove fruits, using the web application.
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/spring/spring-rhoar-intro/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `spring-rhoar-intro` project inside the `spring` folder contains the completed solution for this scenario.
+
 ## Congratulations
 
 You have now learned how to deploy a Spring Boot application using a database to OpenShift Container Platform. This concludes the first learning scenario for Spring Boot. 

--- a/middleware/middleware-spring-boot/spring-getting-started/env-init.sh
+++ b/middleware/middleware-spring-boot/spring-getting-started/env-init.sh
@@ -1,2 +1,16 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-rhoar-intro
 echo "-w \"\n\"" >> ~/.curlrc
+
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
+
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-spring-boot/spring-getting-started/set-env.sh
+++ b/middleware/middleware-spring-boot/spring-getting-started/set-env.sh
@@ -3,15 +3,12 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-rhoar-intro
 cd /root/projects/rhoar-getting-started/spring/spring-rhoar-intro
 
-# Install Java 11
-wget -O /tmp/jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/jdk.tar.gz && \
-rm -rf /tmp/jdk.tar.gz && \
-export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
-export PATH=$JAVA_HOME/bin:$PATH && \
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
-
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-spring-boot/spring-messaging/04-deploy-to-openshift.md
+++ b/middleware/middleware-spring-boot/spring-messaging/04-deploy-to-openshift.md
@@ -39,7 +39,26 @@ After the Maven build/deploy is finished, it will typically take less than 20 se
 
 ![Spring Messaging App Route](/openshift/assets/middleware/rhoar-messaging/spring-messaging-training-route.png)
 
-You should see the same web application as before. The scheduled Producer will continue to deploy messages every 3 seconds so you should observe a change in the values shown. The number of items in the list will remain 5. 
+You should see the same web application as before. The scheduled Producer will continue to deploy messages every 3 seconds so you should observe a change in the values shown. The number of items in the list will remain 5.
+
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/spring/spring-messaging/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `spring-messaging` project inside the `spring` folder contains the completed solution for this scenario.
 
 ## Congratulations
 

--- a/middleware/middleware-spring-boot/spring-messaging/env-init.sh
+++ b/middleware/middleware-spring-boot/spring-messaging/env-init.sh
@@ -1,2 +1,16 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-messaging
 echo "-w \"\n\"" >> ~/.curlrc
+
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
+
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-spring-boot/spring-messaging/set-env.sh
+++ b/middleware/middleware-spring-boot/spring-messaging/set-env.sh
@@ -3,15 +3,12 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-messaging
 cd /root/projects/rhoar-getting-started/spring/spring-messaging
 
-# Install Java 11
-wget -O /tmp/jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/jdk.tar.gz && \
-rm -rf /tmp/jdk.tar.gz && \
-export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
-export PATH=$JAVA_HOME/bin:$PATH && \
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
-
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc

--- a/middleware/middleware-spring-boot/spring-rest-services/03-login-to-openshift.md
+++ b/middleware/middleware-spring-boot/spring-rest-services/03-login-to-openshift.md
@@ -52,6 +52,25 @@ You should see the same JSON output as the previous step:
 ```
 And if you open the [web application](http://spring-rest-services-dev.[[HOST_SUBDOMAIN]]-80-[[KATACODA_HOST]].environments.katacoda.com/) the same functionality from the previous steps should still work.
 
+# Open the solution in an IDE in the Cloud!
+Want to continue exploring this solution on your own in the cloud? You can use the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox). [Click here](https://workspaces.openshift.com) to login or to register if you are a new user. This free service expires after 30 days, but you can always enable a new free 30-day subscription.
+
+Once logged in, [click here](https://workspaces.openshift.com/f?url=https://raw.githubusercontent.com/openshift-katacoda/rhoar-getting-started/solution/spring/spring-rest-services/devfile.yaml) to open the solution for this project in the cloud IDE. While loading, if it asks you to update or install any plugins, you can say no.
+
+# Fork the source code to your own GitHub!
+Want to experiment more with the solution code you just worked with? If so, you can fork the repository containing the solution to your own GitHub repository by clicking on the following command to execute it:
+
+`/root/projects/forkrepo.sh`{{execute T1}}
+- Make sure to follow the prompts. An error saying `Failed opening a web browser at https://github.com/login/device exit status 127` is expected.
+- [Click here](https://github.com/login/device) to open a new browser tab to GitHub and paste in the code you were presented with and you copied.
+- Once done with the GitHub authorization in the browser, close the browser tab and return to the console and press `Enter` to complete the authentication process.
+- If asked to clone the fork, press `n` and then `Enter`.
+- If asked to confirm logout, press `y` and the `Enter`.
+
+   > **NOTE:** This process uses the [GitHub CLI](https://cli.github.com) to authenticate with GitHub. The learn.openshift.com site is not requesting nor will have access to your GitHub credentials.
+
+After completing these steps the `rhoar-getting-started` repo will be forked in your own GitHub account. On the `solution` branch in the repo, the `spring-rest-services` project inside the `spring` folder contains the completed solution for this scenario.
+
 ## Congratulations
 
 You have now learned how to deploy a RESTful Spring Boot application to OpenShift Container Platform. 

--- a/middleware/middleware-spring-boot/spring-rest-services/env-init.sh
+++ b/middleware/middleware-spring-boot/spring-rest-services/env-init.sh
@@ -1,2 +1,16 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-rest-services
 echo "-w \"\n\"" >> ~/.curlrc
+
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-openjdk.sh > /tmp/jdk.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/install-github-cli.sh > /tmp/ghcli.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/setup-xdg-open.sh > /tmp/setup-xdg-open.sh
+curl -sL -w '' https://raw.githubusercontent.com/openshift-labs/learn-katacoda/master/assets/middleware/run-gh-fork.sh > /root/projects/forkrepo.sh
+
+chmod a+x /tmp/jdk.sh
+chmod a+x /tmp/ghcli.sh
+chmod a+x /tmp/setup-xdg-open.sh
+chmod a+x /root/projects/forkrepo.sh
+
+/tmp/setup-xdg-open.sh
+/tmp/jdk.sh
+/tmp/ghcli.sh

--- a/middleware/middleware-spring-boot/spring-rest-services/set-env.sh
+++ b/middleware/middleware-spring-boot/spring-rest-services/set-env.sh
@@ -3,15 +3,12 @@
 mkdir -p /root/projects/rhoar-getting-started/spring/spring-rest-services
 cd /root/projects/rhoar-getting-started/spring/spring-rest-services
 
-# Install Java 11
-wget -O /tmp/jdk.tar.gz https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.10%2B9/OpenJDK11U-jdk_x64_linux_hotspot_11.0.10_9.tar.gz && \
-pushd /usr/local && \
-tar -xvzf /tmp/jdk.tar.gz && \
-rm -rf /tmp/jdk.tar.gz && \
-export JAVA_HOME="/usr/local/jdk-11.0.10+9" && \
-export PATH=$JAVA_HOME/bin:$PATH && \
-echo "export JAVA_HOME=$JAVA_HOME" >> ~/.bashrc && \
-echo "export PATH=$JAVA_HOME/bin:\$PATH" >> ~/.bashrc && \
-popd
-
 clear
+echo 'echo Installing the latest Java runtime..' > /tmp/launch.sh
+echo 'until ${JAVA_HOME}/bin/java --version >& /dev/null ; do sleep 1; echo -n . && source ~/.bashrc; done' >> /tmp/launch.sh
+echo 'echo' >> /tmp/launch.sh
+echo 'echo "Ready!"' >> /tmp/launch.sh
+chmod a+x /tmp/launch.sh
+clear
+/tmp/launch.sh
+source ~/.bashrc


### PR DESCRIPTION
Add an outro to all the Spring & Quarkus scenarios that allows
1. The user to fork the solution repo to their own GitHub
2. A link to open the solution for the project in the free [Red Hat CodeReady Workspaces](https://developers.redhat.com/products/codeready-workspaces/overview) IDE running on the free [Red Hat Developer Sandbox](http://red.ht/dev-sandbox)
    - Support for this was added in openshift-katacoda/rhoar-getting-started#95