### PR TITLE
Update etcd exercise to  openshift-4-7

### DIFF
--- a/operatorframework/etcd-operator/index.json
+++ b/operatorframework/etcd-operator/index.json
@@ -52,7 +52,7 @@
     },
   "backend": {
     "autoUpgrade": true,
-    "imageid": "openshift-4-5",
+    "imageid": "openshift-4-7",
     "port": 8443
   }
 }


### PR DESCRIPTION
Update etcd exercise to  openshift-4-7 to resolve exec and logs errors that are showing up on openshift-4-5 image