### PR TITLE
update op framework exercises to 4.7

### DIFF
--- a/ansibleop/ansible-k8s-modules/index.json
+++ b/ansibleop/ansible-k8s-modules/index.json
@@ -40,7 +40,7 @@
     },
   "backend": {
     "autoUpgrade": true,
-    "imageid": "openshift-4-5",
+    "imageid": "openshift-4-7",
     "port": 8443
   }
 }

--- a/ansibleop/ansible-mcrouter-operator/index.json
+++ b/ansibleop/ansible-mcrouter-operator/index.json
@@ -43,7 +43,7 @@
     },
   "backend": {
     "autoUpgrade": true,
-    "imageid": "openshift-4-5",
+    "imageid": "openshift-4-7",
     "port": 8443
   }
 }

--- a/ansibleop/ansible-operator-overview/index.json
+++ b/ansibleop/ansible-operator-overview/index.json
@@ -52,7 +52,7 @@
     },
   "backend": {
     "autoUpgrade": true,
-    "imageid": "openshift-4-5",
+    "imageid": "openshift-4-7",
     "port": 8443
   }
 }

--- a/operatorframework/go-operator-podset/assets/podset_controller.go
+++ b/operatorframework/go-operator-podset/assets/podset_controller.go
@@ -1,40 +1,60 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (
 	"context"
 	"reflect"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	appv1alpha1 "github.com/redhat/podset-operator/api/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/labels"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // PodSetReconciler reconciles a PodSet object
 type PodSetReconciler struct {
 	client.Client
-	Log    logr.Logger
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=app.example.com,resources=podsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=app.example.com,resources=podsets/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=v1,resources=pods,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=app.example.com,resources=podsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=app.example.com,resources=podsets/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=app.example.com,resources=podsets/finalizers,verbs=update
 
-func (r *PodSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-	_ = context.Background()
-	_ = r.Log.WithValues("podset", req.NamespacedName)
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the PodSet object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
+func (r *PodSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
 
 	// Fetch the PodSet instance
 	instance := &appv1alpha1.PodSet{}
@@ -44,11 +64,13 @@ func (r *PodSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 			// Request object not found, could have been deleted after reconcile request.
 			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
 			// Return and don't requeue
-			return reconcile.Result{}, nil
+			return ctrl.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
-		return reconcile.Result{}, err
+		return ctrl.Result{}, err
+
 	}
+
 	// List all pods owned by this PodSet instance
 	podSet := instance
 	podList := &corev1.PodList{}
@@ -59,7 +81,7 @@ func (r *PodSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	labelSelector := labels.SelectorFromSet(lbs)
 	listOps := &client.ListOptions{Namespace: podSet.Namespace, LabelSelector: labelSelector}
 	if err = r.List(context.TODO(), podList, listOps); err != nil {
-		return reconcile.Result{}, err
+		return ctrl.Result{}, err
 	}
 
 	// Count the pods that are pending or running as available
@@ -87,42 +109,42 @@ func (r *PodSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		podSet.Status = status
 		err = r.Status().Update(context.TODO(), podSet)
 		if err != nil {
-			r.Log.Error(err, "Failed to update PodSet status")
-			return reconcile.Result{}, err
+			log.Error(err, "Failed to update PodSet status")
+			return ctrl.Result{}, err
 		}
 	}
 
 	if numAvailable > podSet.Spec.Replicas {
-		r.Log.Info("Scaling down pods", "Currently available", numAvailable, "Required replicas", podSet.Spec.Replicas)
+		log.Info("Scaling down pods", "Currently available", numAvailable, "Required replicas", podSet.Spec.Replicas)
 		diff := numAvailable - podSet.Spec.Replicas
 		dpods := available[:diff]
 		for _, dpod := range dpods {
 			err = r.Delete(context.TODO(), &dpod)
 			if err != nil {
-				r.Log.Error(err, "Failed to delete pod", "pod.name", dpod.Name)
-				return reconcile.Result{}, err
+				log.Error(err, "Failed to delete pod", "pod.name", dpod.Name)
+				return ctrl.Result{}, err
 			}
 		}
-		return reconcile.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	if numAvailable < podSet.Spec.Replicas {
-		r.Log.Info("Scaling up pods", "Currently available", numAvailable, "Required replicas", podSet.Spec.Replicas)
+		log.Info("Scaling up pods", "Currently available", numAvailable, "Required replicas", podSet.Spec.Replicas)
 		// Define a new Pod object
 		pod := newPodForCR(podSet)
 		// Set PodSet instance as the owner and controller
 		if err := controllerutil.SetControllerReference(podSet, pod, r.Scheme); err != nil {
-			return reconcile.Result{}, err
+			return ctrl.Result{}, err
 		}
 		err = r.Create(context.TODO(), pod)
 		if err != nil {
-			r.Log.Error(err, "Failed to create pod", "pod.name", pod.Name)
-			return reconcile.Result{}, err
+			log.Error(err, "Failed to create pod", "pod.name", pod.Name)
+			return ctrl.Result{}, err
 		}
-		return reconcile.Result{Requeue: true}, nil
+		return ctrl.Result{Requeue: true}, nil
 	}
 
-	return reconcile.Result{}, nil
+	return ctrl.Result{}, nil
 }
 
 // newPodForCR returns a busybox pod with the same name/namespace as the cr
@@ -149,7 +171,7 @@ func newPodForCR(cr *appv1alpha1.PodSet) *corev1.Pod {
 	}
 }
 
-//SetupWithManager defines how the controller will watch for resources
+// SetupWithManager sets up the controller with the Manager.
 func (r *PodSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appv1alpha1.PodSet{}).

--- a/operatorframework/go-operator-podset/index.json
+++ b/operatorframework/go-operator-podset/index.json
@@ -49,7 +49,7 @@
     },
   "backend": {
     "autoUpgrade": true,
-    "imageid": "openshift-4-5",
+    "imageid": "openshift-4-7",
     "port": 8443
   }
 }

--- a/operatorframework/go-operator-podset/step4.md
+++ b/operatorframework/go-operator-podset/step4.md
@@ -9,163 +9,185 @@ This default controller requires additional logic so we can trigger our reconcil
 Modify the PodSet controller logic at `controllers/podset_controller.go`:
 
 <pre class="file">
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package controllers
 
 import (
-        "context"
-        "reflect"
+	"context"
+	"reflect"
 
-        "github.com/go-logr/logr"
-        "k8s.io/apimachinery/pkg/runtime"
-        ctrl "sigs.k8s.io/controller-runtime"
-        "sigs.k8s.io/controller-runtime/pkg/client"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
-        appv1alpha1 "github.com/redhat/podset-operator/api/v1alpha1"
+	appv1alpha1 "github.com/redhat/podset-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-        "k8s.io/apimachinery/pkg/labels"
-        "sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-        "sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-        "k8s.io/apimachinery/pkg/api/errors"
-        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-        corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 // PodSetReconciler reconciles a PodSet object
 type PodSetReconciler struct {
-        client.Client
-        Log    logr.Logger
-        Scheme *runtime.Scheme
+	client.Client
+	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=app.example.com,resources=podsets,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=app.example.com,resources=podsets/status,verbs=get;update;patch
-// +kubebuilder:rbac:groups=v1,resources=pods,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=app.example.com,resources=podsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=app.example.com,resources=podsets/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=app.example.com,resources=podsets/finalizers,verbs=update
 
-func (r *PodSetReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
-        _ = context.Background()
-        _ = r.Log.WithValues("podset", req.NamespacedName)
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// TODO(user): Modify the Reconcile function to compare the state specified by
+// the PodSet object against the actual cluster state, and then
+// perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
+func (r *PodSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrllog.FromContext(ctx)
 
-        // Fetch the PodSet instance
-        instance := &appv1alpha1.PodSet{}
-        err := r.Get(context.TODO(), req.NamespacedName, instance)
-        if err != nil {
-                if errors.IsNotFound(err) {
-                        // Request object not found, could have been deleted after reconcile request.
-                        // Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
-                        // Return and don't requeue
-                        return reconcile.Result{}, nil
-                }
-                // Error reading the object - requeue the request.
-                return reconcile.Result{}, err
-        }
-        // List all pods owned by this PodSet instance
-        podSet := instance
-        podList := &corev1.PodList{}
-        lbs := map[string]string{
-                "app":     podSet.Name,
-                "version": "v0.1",
-        }
-        labelSelector := labels.SelectorFromSet(lbs)
-        listOps := &client.ListOptions{Namespace: podSet.Namespace, LabelSelector: labelSelector}
-        if err = r.List(context.TODO(), podList, listOps); err != nil {
-                return reconcile.Result{}, err
-        }
+	// Fetch the PodSet instance
+	instance := &appv1alpha1.PodSet{}
+	err := r.Get(context.TODO(), req.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Request object not found, could have been deleted after reconcile request.
+			// Owned objects are automatically garbage collected. For additional cleanup logic use finalizers.
+			// Return and don't requeue
+			return ctrl.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return ctrl.Result{}, err
 
-        // Count the pods that are pending or running as available
-        var available []corev1.Pod
-        for _, pod := range podList.Items {
-                if pod.ObjectMeta.DeletionTimestamp != nil {
-                        continue
-                }
-                if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending {
-                        available = append(available, pod)
-                }
-        }
-        numAvailable := int32(len(available))
-        availableNames := []string{}
-        for _, pod := range available {
-                availableNames = append(availableNames, pod.ObjectMeta.Name)
-        }
+	}
 
-        // Update the status if necessary
-        status := appv1alpha1.PodSetStatus{
-                PodNames: availableNames,
-                AvailableReplicas: numAvailable,
-        }
-        if !reflect.DeepEqual(podSet.Status, status) {
-                podSet.Status = status
-                err = r.Status().Update(context.TODO(), podSet)
-                if err != nil {
-                        r.Log.Error(err, "Failed to update PodSet status")
-                        return reconcile.Result{}, err
-                }
-        }
+	// List all pods owned by this PodSet instance
+	podSet := instance
+	podList := &corev1.PodList{}
+	lbs := map[string]string{
+		"app":     podSet.Name,
+		"version": "v0.1",
+	}
+	labelSelector := labels.SelectorFromSet(lbs)
+	listOps := &client.ListOptions{Namespace: podSet.Namespace, LabelSelector: labelSelector}
+	if err = r.List(context.TODO(), podList, listOps); err != nil {
+		return ctrl.Result{}, err
+	}
 
-        if numAvailable > podSet.Spec.Replicas {
-                r.Log.Info("Scaling down pods", "Currently available", numAvailable, "Required replicas", podSet.Spec.Replicas)
-                diff := numAvailable - podSet.Spec.Replicas
-                dpods := available[:diff]
-                for _, dpod := range dpods {
-                        err = r.Delete(context.TODO(), &dpod)
-                        if err != nil {
-                                r.Log.Error(err, "Failed to delete pod", "pod.name", dpod.Name)
-                                return reconcile.Result{}, err
-                        }
-                }
-                return reconcile.Result{Requeue: true}, nil
-        }
+	// Count the pods that are pending or running as available
+	var available []corev1.Pod
+	for _, pod := range podList.Items {
+		if pod.ObjectMeta.DeletionTimestamp != nil {
+			continue
+		}
+		if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending {
+			available = append(available, pod)
+		}
+	}
+	numAvailable := int32(len(available))
+	availableNames := []string{}
+	for _, pod := range available {
+		availableNames = append(availableNames, pod.ObjectMeta.Name)
+	}
 
-        if numAvailable < podSet.Spec.Replicas {
-                r.Log.Info("Scaling up pods", "Currently available", numAvailable, "Required replicas", podSet.Spec.Replicas)
-                // Define a new Pod object
-                pod := newPodForCR(podSet)
-                // Set PodSet instance as the owner and controller
-                if err := controllerutil.SetControllerReference(podSet, pod, r.Scheme); err != nil {
-                        return reconcile.Result{}, err
-                }
-                err = r.Create(context.TODO(), pod)
-                if err != nil {
-                        r.Log.Error(err, "Failed to create pod", "pod.name", pod.Name)
-                        return reconcile.Result{}, err
-                }
-                return reconcile.Result{Requeue: true}, nil
-        }
+	// Update the status if necessary
+	status := appv1alpha1.PodSetStatus{
+		PodNames:          availableNames,
+		AvailableReplicas: numAvailable,
+	}
+	if !reflect.DeepEqual(podSet.Status, status) {
+		podSet.Status = status
+		err = r.Status().Update(context.TODO(), podSet)
+		if err != nil {
+			log.Error(err, "Failed to update PodSet status")
+			return ctrl.Result{}, err
+		}
+	}
 
-        return reconcile.Result{}, nil
+	if numAvailable > podSet.Spec.Replicas {
+		log.Info("Scaling down pods", "Currently available", numAvailable, "Required replicas", podSet.Spec.Replicas)
+		diff := numAvailable - podSet.Spec.Replicas
+		dpods := available[:diff]
+		for _, dpod := range dpods {
+			err = r.Delete(context.TODO(), &dpod)
+			if err != nil {
+				log.Error(err, "Failed to delete pod", "pod.name", dpod.Name)
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	if numAvailable < podSet.Spec.Replicas {
+		log.Info("Scaling up pods", "Currently available", numAvailable, "Required replicas", podSet.Spec.Replicas)
+		// Define a new Pod object
+		pod := newPodForCR(podSet)
+		// Set PodSet instance as the owner and controller
+		if err := controllerutil.SetControllerReference(podSet, pod, r.Scheme); err != nil {
+			return ctrl.Result{}, err
+		}
+		err = r.Create(context.TODO(), pod)
+		if err != nil {
+			log.Error(err, "Failed to create pod", "pod.name", pod.Name)
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
+	}
+
+	return ctrl.Result{}, nil
 }
 
 // newPodForCR returns a busybox pod with the same name/namespace as the cr
 func newPodForCR(cr *appv1alpha1.PodSet) *corev1.Pod {
-        labels := map[string]string{
-                "app":     cr.Name,
-                "version": "v0.1",
-        }
-        return &corev1.Pod{
-                ObjectMeta: metav1.ObjectMeta{
-                        GenerateName: cr.Name + "-pod",
-                        Namespace:    cr.Namespace,
-                        Labels:       labels,
-                },
-                Spec: corev1.PodSpec{
-                        Containers: []corev1.Container{
-                                {
-                                        Name:    "busybox",
-                                        Image:   "busybox",
-                                        Command: []string{"sleep", "3600"},
-                                },
-                        },
-                },
-        }
+	labels := map[string]string{
+		"app":     cr.Name,
+		"version": "v0.1",
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: cr.Name + "-pod",
+			Namespace:    cr.Namespace,
+			Labels:       labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "busybox",
+					Image:   "busybox",
+					Command: []string{"sleep", "3600"},
+				},
+			},
+		},
+	}
 }
 
-//SetupWithManager defines how the controller will watch for resources
+// SetupWithManager sets up the controller with the Manager.
 func (r *PodSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
-        return ctrl.NewControllerManagedBy(mgr).
-                For(&appv1alpha1.PodSet{}).
-                Owns(&corev1.Pod{}).
-                Complete(r)
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&appv1alpha1.PodSet{}).
+		Owns(&corev1.Pod{}).
+		Complete(r)
 }
 </pre>
 
@@ -173,5 +195,11 @@ You can easily update this file by running the following command:
 
 ```
 \cp /tmp/podset_controller.go controllers/podset_controller.go
+```{{execute}}
+
+`go mod tidy`  ensures that the go.mod file matches the source code in the module. It adds any missing module requirements necessary to build the current module's packages and dependencies, and it removes requirements on modules that don't provide any relevant packages. It also adds any missing entries to go.sum and removes unnecessary entries.
+
+```
+go mod tidy
 ```{{execute}}
 

--- a/operatorframework/helm-operator/index.json
+++ b/operatorframework/helm-operator/index.json
@@ -55,7 +55,7 @@
     },
   "backend": {
     "autoUpgrade": true,
-    "imageid": "openshift-4-5",
+    "imageid": "openshift-4-7",
     "port": 8443
   }
 }

--- a/operatorframework/helm-operator/step4.md
+++ b/operatorframework/helm-operator/step4.md
@@ -7,7 +7,7 @@ Before applying the CockroachDB Custom Resource, observe the CockroachDB Helm Ch
 
 [CockroachDB Helm Chart Values.yaml file](https://github.com/helm/charts/blob/master/stable/cockroachdb/values.yaml)
 
-Update the CockroachDB Custom Resource at `go/src/github.com/redhat/cockroachdb-operator/deploy/crds/charts.helm.k8s.io_v1alpha1_cockroachdb_cr.yaml` with the following values:
+Update the CockroachDB Custom Resource at `config/samples/charts_v1alpha1_cockroachdb.yaml` with the following values:
 
 * `spec.statefulset.replicas: 1`
 * `spec.storage.persistentVolume.size: 1Gi`

--- a/operatorframework/k8s-api-fundamentals/index.json
+++ b/operatorframework/k8s-api-fundamentals/index.json
@@ -43,7 +43,7 @@
     },
   "backend": {
     "autoUpgrade": true,
-    "imageid": "openshift-4-5",
+    "imageid": "openshift-4-7",
     "port": 8443
   }
 }

--- a/operatorframework/operator-lifecycle-manager/index.json
+++ b/operatorframework/operator-lifecycle-manager/index.json
@@ -52,7 +52,7 @@
   },
   "backend": {
     "autoUpgrade": true,
-    "imageid": "openshift-4-5",
+    "imageid": "openshift-4-7",
     "port": 8443
   }
 }


### PR DESCRIPTION
Updates all operator exercises to openshift-4-7 image which should eliminate #1288, #1286, #1285, #1284, #1282, #1277, #1276, #1275 